### PR TITLE
feat(feature-registry): Phase 3 plugin registration contract

### DIFF
--- a/packages/feature-registry/package.json
+++ b/packages/feature-registry/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@ficecal/feature-registry",
+  "version": "0.1.0",
+  "description": "FiceCal v2 feature descriptor and plugin registration contract",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/feature-registry/src/index.ts
+++ b/packages/feature-registry/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  FeatureDescriptor,
+  FeatureRegistryEntry,
+  FeatureRegistryErrorCode,
+  RegistryValidationResult,
+} from "./types.js";
+
+export { FeatureRegistryError } from "./types.js";
+export { FeatureRegistry } from "./registry.js";

--- a/packages/feature-registry/src/registry.ts
+++ b/packages/feature-registry/src/registry.ts
@@ -1,0 +1,247 @@
+import type {
+  FeatureDescriptor,
+  FeatureRegistryEntry,
+  RegistryValidationResult,
+} from "./types.js";
+import { FeatureRegistryError } from "./types.js";
+
+/**
+ * FiceCal feature/plugin registry.
+ *
+ * Lifecycle:
+ * 1. `register(descriptor)` — add a feature (throws on duplicate id)
+ * 2. `validate()` — check all declared dependencies are satisfied
+ * 3. `resolve(ids?)` — return entries in dependency-safe topological order
+ * 4. `lookup(id)` / `require(id)` — point lookups
+ * 5. `findByCapability(token)` — capability-based discovery
+ */
+export class FeatureRegistry {
+  private readonly entries = new Map<string, FeatureRegistryEntry>();
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  /**
+   * Register a feature descriptor.
+   * @throws {FeatureRegistryError} DUPLICATE_ID if the id is already registered.
+   * @throws {FeatureRegistryError} INVALID_DESCRIPTOR if id or version is empty.
+   */
+  register(descriptor: FeatureDescriptor): void {
+    if (!descriptor.id || descriptor.id.trim() === "") {
+      throw new FeatureRegistryError(
+        "Feature descriptor must have a non-empty id",
+        "INVALID_DESCRIPTOR",
+      );
+    }
+    if (!descriptor.version || descriptor.version.trim() === "") {
+      throw new FeatureRegistryError(
+        `Feature '${descriptor.id}' must have a non-empty version`,
+        "INVALID_DESCRIPTOR",
+        descriptor.id,
+      );
+    }
+    if (this.entries.has(descriptor.id)) {
+      throw new FeatureRegistryError(
+        `Feature '${descriptor.id}' is already registered`,
+        "DUPLICATE_ID",
+        descriptor.id,
+      );
+    }
+
+    this.entries.set(descriptor.id, {
+      descriptor,
+      registeredAt: new Date().toISOString(),
+    });
+  }
+
+  // ── Lookup ────────────────────────────────────────────────────────────────
+
+  /** Returns the entry or `undefined` if not found. */
+  lookup(id: string): FeatureRegistryEntry | undefined {
+    return this.entries.get(id);
+  }
+
+  /**
+   * Returns the entry.
+   * @throws {FeatureRegistryError} NOT_FOUND if the id is not registered.
+   */
+  require(id: string): FeatureRegistryEntry {
+    const entry = this.entries.get(id);
+    if (entry === undefined) {
+      throw new FeatureRegistryError(
+        `Feature '${id}' is not registered`,
+        "NOT_FOUND",
+        id,
+      );
+    }
+    return entry;
+  }
+
+  /** Returns all registered entries (insertion order, not resolved order). */
+  list(): FeatureRegistryEntry[] {
+    return [...this.entries.values()];
+  }
+
+  /** Returns all ids currently registered. */
+  ids(): string[] {
+    return [...this.entries.keys()];
+  }
+
+  // ── Capability query ──────────────────────────────────────────────────────
+
+  /**
+   * Returns all entries that expose a given capability token.
+   * Example: `registry.findByCapability("cost-compute")`
+   */
+  findByCapability(token: string): FeatureRegistryEntry[] {
+    return [...this.entries.values()].filter((e) =>
+      e.descriptor.provides.includes(token),
+    );
+  }
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  /**
+   * Validates that all declared dependencies are registered and
+   * that there are no circular dependency chains.
+   */
+  validate(): RegistryValidationResult {
+    const errors: RegistryValidationResult["errors"] = [];
+
+    for (const entry of this.entries.values()) {
+      const { id, dependsOn } = entry.descriptor;
+
+      // Check all dependencies are registered
+      for (const dep of dependsOn) {
+        if (!this.entries.has(dep)) {
+          errors.push({
+            featureId: id,
+            message: `Declared dependency '${dep}' is not registered`,
+            code: "MISSING_DEPENDENCY",
+          });
+        }
+      }
+    }
+
+    // Check for circular dependencies (only if no missing deps)
+    if (errors.length === 0) {
+      try {
+        this._topologicalSort([...this.entries.keys()]);
+      } catch (e) {
+        if (e instanceof FeatureRegistryError && e.code === "CIRCULAR_DEPENDENCY") {
+          errors.push({
+            featureId: e.featureId ?? "unknown",
+            message: e.message,
+            code: "CIRCULAR_DEPENDENCY",
+          });
+        }
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  // ── Resolution ────────────────────────────────────────────────────────────
+
+  /**
+   * Returns entries in dependency-safe topological order.
+   *
+   * If `ids` is provided, only those features (and their transitive
+   * dependencies) are included. Otherwise all registered features are resolved.
+   *
+   * @throws {FeatureRegistryError} NOT_FOUND — if a requested id is not registered
+   * @throws {FeatureRegistryError} MISSING_DEPENDENCY — if a dependency is absent
+   * @throws {FeatureRegistryError} CIRCULAR_DEPENDENCY — if a cycle is detected
+   */
+  resolve(ids?: string[]): FeatureRegistryEntry[] {
+    const rootIds = ids ?? [...this.entries.keys()];
+
+    // Validate requested ids exist
+    for (const id of rootIds) {
+      if (!this.entries.has(id)) {
+        throw new FeatureRegistryError(
+          `Cannot resolve: feature '${id}' is not registered`,
+          "NOT_FOUND",
+          id,
+        );
+      }
+    }
+
+    const sorted = this._topologicalSort(rootIds);
+    return sorted.map((id) => this.entries.get(id)!);
+  }
+
+  // ── Internal: Kahn's topological sort ────────────────────────────────────
+
+  private _topologicalSort(rootIds: string[]): string[] {
+    // Expand to full transitive closure
+    const visited = new Set<string>();
+    const toVisit = [...rootIds];
+
+    while (toVisit.length > 0) {
+      const id = toVisit.pop()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+
+      const entry = this.entries.get(id);
+      if (!entry) {
+        throw new FeatureRegistryError(
+          `Dependency '${id}' is not registered`,
+          "MISSING_DEPENDENCY",
+          id,
+        );
+      }
+      for (const dep of entry.descriptor.dependsOn) {
+        if (!visited.has(dep)) toVisit.push(dep);
+      }
+    }
+
+    // Kahn's algorithm on the subgraph
+    const inDegree = new Map<string, number>();
+    const adjList = new Map<string, string[]>(); // id → dependents
+
+    for (const id of visited) {
+      if (!inDegree.has(id)) inDegree.set(id, 0);
+      if (!adjList.has(id)) adjList.set(id, []);
+    }
+
+    for (const id of visited) {
+      const entry = this.entries.get(id)!;
+      for (const dep of entry.descriptor.dependsOn) {
+        if (!visited.has(dep)) continue;
+        adjList.get(dep)!.push(id);
+        inDegree.set(id, (inDegree.get(id) ?? 0) + 1);
+      }
+    }
+
+    const queue: string[] = [];
+    for (const [id, degree] of inDegree) {
+      if (degree === 0) queue.push(id);
+    }
+
+    const result: string[] = [];
+    while (queue.length > 0) {
+      // Sort for deterministic output
+      queue.sort();
+      const id = queue.shift()!;
+      result.push(id);
+
+      for (const dependent of adjList.get(id) ?? []) {
+        const newDegree = (inDegree.get(dependent) ?? 0) - 1;
+        inDegree.set(dependent, newDegree);
+        if (newDegree === 0) queue.push(dependent);
+      }
+    }
+
+    if (result.length !== visited.size) {
+      // There's a cycle — find which nodes weren't processed
+      const remaining = [...visited].filter((id) => !result.includes(id));
+      throw new FeatureRegistryError(
+        `Circular dependency detected among: ${remaining.join(", ")}`,
+        "CIRCULAR_DEPENDENCY",
+        remaining[0],
+      );
+    }
+
+    return result;
+  }
+}

--- a/packages/feature-registry/src/types.ts
+++ b/packages/feature-registry/src/types.ts
@@ -1,0 +1,70 @@
+// ─── Feature descriptor ───────────────────────────────────────────────────────
+
+/**
+ * Describes a registerable FiceCal feature or plugin.
+ *
+ * The registry uses this contract to:
+ * - Detect duplicate registrations (by id)
+ * - Resolve dependency load order (topological sort)
+ * - Surface capability queries (by provides)
+ */
+export interface FeatureDescriptor {
+  /**
+   * Globally unique feature identifier.
+   * Convention: `<scope>.<name>` — e.g. "economics.core", "billing.aws"
+   */
+  id: string;
+
+  /** Semver-compatible version string. */
+  version: string;
+
+  /**
+   * IDs of features that must be registered before this one can be resolved.
+   * The registry validates these are present and resolves a load order.
+   */
+  dependsOn: string[];
+
+  /**
+   * Capability tokens this feature exposes to consumers.
+   * Other features can query the registry by capability rather than id.
+   * Example: ["cost-compute", "forex-conversion"]
+   */
+  provides: string[];
+
+  /** Arbitrary metadata — stable KV bag for tooling and introspection. */
+  metadata?: Record<string, unknown>;
+}
+
+// ─── Registry entry ───────────────────────────────────────────────────────────
+
+export interface FeatureRegistryEntry {
+  descriptor: FeatureDescriptor;
+  registeredAt: string; // ISO timestamp
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export type FeatureRegistryErrorCode =
+  | "DUPLICATE_ID"
+  | "NOT_FOUND"
+  | "MISSING_DEPENDENCY"
+  | "CIRCULAR_DEPENDENCY"
+  | "INVALID_DESCRIPTOR";
+
+export class FeatureRegistryError extends Error {
+  constructor(
+    message: string,
+    public readonly code: FeatureRegistryErrorCode,
+    public readonly featureId?: string,
+  ) {
+    super(message);
+    this.name = "FeatureRegistryError";
+  }
+}
+
+// ─── Validation result ────────────────────────────────────────────────────────
+
+export interface RegistryValidationResult {
+  valid: boolean;
+  errors: Array<{ featureId: string; message: string; code: FeatureRegistryErrorCode }>;
+}

--- a/packages/feature-registry/tests/registry.test.ts
+++ b/packages/feature-registry/tests/registry.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { FeatureRegistry, FeatureRegistryError } from "../src/index.js";
+import type { FeatureDescriptor } from "../src/index.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function desc(
+  id: string,
+  overrides: Partial<FeatureDescriptor> = {},
+): FeatureDescriptor {
+  return {
+    id,
+    version: "0.1.0",
+    dependsOn: [],
+    provides: [],
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("FeatureRegistry", () => {
+  let registry: FeatureRegistry;
+
+  beforeEach(() => {
+    registry = new FeatureRegistry();
+  });
+
+  // ── Registration ────────────────────────────────────────────────────────
+
+  describe("register", () => {
+    it("registers a feature successfully", () => {
+      registry.register(desc("economics.core"));
+      expect(registry.lookup("economics.core")).toBeDefined();
+    });
+
+    it("throws DUPLICATE_ID when registering the same id twice", () => {
+      registry.register(desc("economics.core"));
+      expect(() => registry.register(desc("economics.core"))).toThrowError(
+        FeatureRegistryError,
+      );
+      try {
+        registry.register(desc("economics.core"));
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("DUPLICATE_ID");
+      }
+    });
+
+    it("throws INVALID_DESCRIPTOR when id is empty", () => {
+      expect(() => registry.register(desc(""))).toThrowError(FeatureRegistryError);
+      try {
+        registry.register(desc(""));
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("INVALID_DESCRIPTOR");
+      }
+    });
+
+    it("throws INVALID_DESCRIPTOR when version is empty", () => {
+      expect(() =>
+        registry.register({ id: "x", version: "", dependsOn: [], provides: [] }),
+      ).toThrowError(FeatureRegistryError);
+    });
+
+    it("stores registeredAt as a valid ISO timestamp", () => {
+      registry.register(desc("economics.core"));
+      const entry = registry.require("economics.core");
+      expect(new Date(entry.registeredAt).toISOString()).toBe(entry.registeredAt);
+    });
+
+    it("preserves metadata", () => {
+      registry.register(desc("economics.core", { metadata: { author: "ficecal" } }));
+      expect(registry.require("economics.core").descriptor.metadata?.["author"]).toBe(
+        "ficecal",
+      );
+    });
+  });
+
+  // ── Lookup ──────────────────────────────────────────────────────────────
+
+  describe("lookup / require", () => {
+    it("lookup returns undefined for unknown id", () => {
+      expect(registry.lookup("unknown")).toBeUndefined();
+    });
+
+    it("require throws NOT_FOUND for unknown id", () => {
+      try {
+        registry.require("unknown");
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("NOT_FOUND");
+        expect((e as FeatureRegistryError).featureId).toBe("unknown");
+      }
+    });
+
+    it("list returns all registered entries", () => {
+      registry.register(desc("a"));
+      registry.register(desc("b"));
+      expect(registry.list()).toHaveLength(2);
+    });
+
+    it("ids returns all registered ids", () => {
+      registry.register(desc("a"));
+      registry.register(desc("b"));
+      expect(registry.ids()).toEqual(expect.arrayContaining(["a", "b"]));
+    });
+  });
+
+  // ── Capability query ─────────────────────────────────────────────────────
+
+  describe("findByCapability", () => {
+    it("returns features that provide a capability token", () => {
+      registry.register(desc("a", { provides: ["cost-compute"] }));
+      registry.register(desc("b", { provides: ["cost-compute", "forex"] }));
+      registry.register(desc("c", { provides: ["forex"] }));
+
+      const result = registry.findByCapability("cost-compute");
+      expect(result.map((e) => e.descriptor.id)).toEqual(
+        expect.arrayContaining(["a", "b"]),
+      );
+    });
+
+    it("returns empty array when no feature provides the token", () => {
+      registry.register(desc("a", { provides: ["forex"] }));
+      expect(registry.findByCapability("cost-compute")).toHaveLength(0);
+    });
+
+    it("returns empty array on empty registry", () => {
+      expect(registry.findByCapability("cost-compute")).toHaveLength(0);
+    });
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  describe("validate", () => {
+    it("returns valid: true when all dependencies are satisfied", () => {
+      registry.register(desc("core", { provides: ["compute"] }));
+      registry.register(desc("extension", { dependsOn: ["core"] }));
+      expect(registry.validate().valid).toBe(true);
+    });
+
+    it("returns valid: false when a dependency is missing", () => {
+      registry.register(desc("extension", { dependsOn: ["missing-core"] }));
+      const result = registry.validate();
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]?.code).toBe("MISSING_DEPENDENCY");
+    });
+
+    it("returns valid: false and identifies circular dependency", () => {
+      registry.register(desc("a", { dependsOn: ["b"] }));
+      registry.register(desc("b", { dependsOn: ["a"] }));
+      const result = registry.validate();
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]?.code).toBe("CIRCULAR_DEPENDENCY");
+    });
+
+    it("returns valid: true on empty registry", () => {
+      expect(registry.validate().valid).toBe(true);
+    });
+
+    it("returns multiple errors for multiple missing deps", () => {
+      registry.register(desc("a", { dependsOn: ["missing-1"] }));
+      registry.register(desc("b", { dependsOn: ["missing-2"] }));
+      const result = registry.validate();
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ── Resolution / topological sort ─────────────────────────────────────────
+
+  describe("resolve", () => {
+    it("returns single feature with no deps", () => {
+      registry.register(desc("core"));
+      const resolved = registry.resolve(["core"]);
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0]?.descriptor.id).toBe("core");
+    });
+
+    it("resolves dependency before dependent", () => {
+      registry.register(desc("core"));
+      registry.register(desc("extension", { dependsOn: ["core"] }));
+      registry.register(desc("plugin", { dependsOn: ["extension"] }));
+
+      const resolved = registry.resolve(["plugin"]);
+      const ids = resolved.map((e) => e.descriptor.id);
+      expect(ids.indexOf("core")).toBeLessThan(ids.indexOf("extension"));
+      expect(ids.indexOf("extension")).toBeLessThan(ids.indexOf("plugin"));
+    });
+
+    it("resolves all features when called with no args", () => {
+      registry.register(desc("a"));
+      registry.register(desc("b", { dependsOn: ["a"] }));
+      registry.register(desc("c", { dependsOn: ["b"] }));
+      const resolved = registry.resolve();
+      expect(resolved).toHaveLength(3);
+    });
+
+    it("includes transitive deps when resolving a subset", () => {
+      registry.register(desc("base"));
+      registry.register(desc("mid", { dependsOn: ["base"] }));
+      registry.register(desc("top", { dependsOn: ["mid"] }));
+
+      const resolved = registry.resolve(["top"]);
+      const ids = resolved.map((e) => e.descriptor.id);
+      expect(ids).toContain("base");
+      expect(ids).toContain("mid");
+      expect(ids).toContain("top");
+    });
+
+    it("handles diamond dependency (shared dep used by two features)", () => {
+      // A ← B, A ← C, B ← D, C ← D
+      // D depends on both B and C which both depend on A
+      registry.register(desc("A"));
+      registry.register(desc("B", { dependsOn: ["A"] }));
+      registry.register(desc("C", { dependsOn: ["A"] }));
+      registry.register(desc("D", { dependsOn: ["B", "C"] }));
+
+      const resolved = registry.resolve(["D"]);
+      const ids = resolved.map((e) => e.descriptor.id);
+
+      // A must come before B and C; B and C before D
+      expect(ids.indexOf("A")).toBeLessThan(ids.indexOf("B"));
+      expect(ids.indexOf("A")).toBeLessThan(ids.indexOf("C"));
+      expect(ids.indexOf("B")).toBeLessThan(ids.indexOf("D"));
+      expect(ids.indexOf("C")).toBeLessThan(ids.indexOf("D"));
+
+      // No duplicates
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("throws NOT_FOUND when resolving an unregistered id", () => {
+      expect(() => registry.resolve(["missing"])).toThrowError(FeatureRegistryError);
+      try {
+        registry.resolve(["missing"]);
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("NOT_FOUND");
+      }
+    });
+
+    it("throws CIRCULAR_DEPENDENCY when resolve encounters a cycle", () => {
+      registry.register(desc("x", { dependsOn: ["y"] }));
+      registry.register(desc("y", { dependsOn: ["x"] }));
+      expect(() => registry.resolve()).toThrowError(FeatureRegistryError);
+      try {
+        registry.resolve();
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("CIRCULAR_DEPENDENCY");
+      }
+    });
+
+    it("produces deterministic order across multiple calls", () => {
+      registry.register(desc("c"));
+      registry.register(desc("a"));
+      registry.register(desc("b", { dependsOn: ["a", "c"] }));
+
+      const first = registry.resolve().map((e) => e.descriptor.id);
+      const second = registry.resolve().map((e) => e.descriptor.id);
+      expect(first).toEqual(second);
+    });
+  });
+
+  // ── Real-world scenario ───────────────────────────────────────────────────
+
+  describe("FiceCal package graph", () => {
+    it("resolves a realistic FiceCal package dependency graph", () => {
+      registry.register(desc("schemas", { provides: ["model-pricing-schema"] }));
+      registry.register(desc("core-economics", { provides: ["cost-compute", "forex"] }));
+      registry.register(
+        desc("integrations", {
+          dependsOn: ["schemas"],
+          provides: ["model-pricing-data"],
+        }),
+      );
+      registry.register(
+        desc("chart-presentation", {
+          dependsOn: ["core-economics"],
+          provides: ["chart-payload"],
+        }),
+      );
+      registry.register(
+        desc("health-score", {
+          provides: ["health-signals"],
+        }),
+      );
+      registry.register(
+        desc("recommendation-module", {
+          dependsOn: ["health-score"],
+          provides: ["recommendations"],
+        }),
+      );
+      registry.register(
+        desc("ai-token-economics", {
+          dependsOn: ["core-economics"],
+          provides: ["ai-cost-compute"],
+        }),
+      );
+
+      const result = registry.validate();
+      expect(result.valid).toBe(true);
+
+      const resolved = registry.resolve();
+      const ids = resolved.map((e) => e.descriptor.id);
+
+      // core deps before their dependents
+      expect(ids.indexOf("schemas")).toBeLessThan(ids.indexOf("integrations"));
+      expect(ids.indexOf("core-economics")).toBeLessThan(ids.indexOf("chart-presentation"));
+      expect(ids.indexOf("core-economics")).toBeLessThan(ids.indexOf("ai-token-economics"));
+      expect(ids.indexOf("health-score")).toBeLessThan(ids.indexOf("recommendation-module"));
+    });
+  });
+});

--- a/packages/feature-registry/tsconfig.json
+++ b/packages/feature-registry/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,18 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.15)
 
+  packages/feature-registry:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.15)
+
   packages/health-score:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

- Delivers `@ficecal/feature-registry` — foundational plugin registration contract for all FiceCal features
- Kahn's topological sort with diamond-dependency and circular-dependency detection
- Capability-based discovery (`findByCapability(token)`) for loose coupling
- 27 vitest tests, all passing

## API

| Method | Description |
|--------|-------------|
| `register(descriptor)` | Add feature; throws `DUPLICATE_ID` or `INVALID_DESCRIPTOR` |
| `lookup(id)` | Returns entry or `undefined` |
| `require(id)` | Returns entry or throws `NOT_FOUND` |
| `list()` | All entries (insertion order) |
| `findByCapability(token)` | Entries exposing a capability token |
| `validate()` | Checks missing deps + circular chains |
| `resolve(ids?)` | Entries in dependency-safe topological order |

## Test plan

- [x] 27/27 vitest tests passing
- [x] Diamond dependency (shared dep, no duplication)
- [x] Circular dependency detection (both validate + resolve)
- [x] Full FiceCal package graph scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature registry package enabling comprehensive feature management with dependency resolution.
  * Features support declaring dependencies, provided capabilities, and optional metadata.
  * Includes validation to detect circular dependencies and verify all dependencies are satisfied.
  * Provides capability-based feature discovery and deterministic dependency ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->