### PR TITLE
feat(mcp-tooling): Phase 3 MCP tool registry + economics tools — closes Gap 5

### DIFF
--- a/packages/mcp-tooling/package.json
+++ b/packages/mcp-tooling/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ficecal/mcp-tooling",
+  "version": "0.1.0",
+  "description": "FiceCal v2 MCP tool descriptor registry and economics tool definitions — Gap 5 close",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ficecal/feature-registry": "workspace:*",
+    "@ficecal/core-economics": "workspace:*",
+    "@ficecal/ai-token-economics": "workspace:*",
+    "@ficecal/health-score": "workspace:*",
+    "@ficecal/recommendation-module": "workspace:*",
+    "decimal.js": "^10.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/mcp-tooling/src/index.ts
+++ b/packages/mcp-tooling/src/index.ts
@@ -1,0 +1,19 @@
+export type {
+  McpMode,
+  McpActor,
+  McpTimeRange,
+  McpContractVersions,
+  McpRequestContext,
+  McpToolEnvelope,
+  McpToolInputSchema,
+  McpToolDescriptor,
+  McpToolResult,
+  McpToolNamespaceManifest,
+  McpCapabilitiesManifest,
+} from "./types.js";
+
+export { McpToolRegistry } from "./tool-registry.js";
+
+export { costEstimateTool } from "./tools/cost-estimate.js";
+export { healthScoreQueryTool } from "./tools/health-score-query.js";
+export { periodNormalizeTool } from "./tools/period-normalize.js";

--- a/packages/mcp-tooling/src/tool-registry.ts
+++ b/packages/mcp-tooling/src/tool-registry.ts
@@ -1,0 +1,129 @@
+import { FeatureRegistry, FeatureRegistryError } from "@ficecal/feature-registry";
+import type { McpCapabilitiesManifest, McpToolDescriptor } from "./types.js";
+
+/**
+ * Registry for MCP tool descriptors.
+ *
+ * Wraps FeatureRegistry for dependency tracking and adds tool-specific
+ * operations: lookup by namespace, capabilities manifest generation.
+ */
+export class McpToolRegistry {
+  private readonly tools = new Map<string, McpToolDescriptor>();
+  private readonly featureRegistry = new FeatureRegistry();
+
+  /**
+   * Register an MCP tool descriptor.
+   * @throws {FeatureRegistryError} DUPLICATE_ID if the tool id is already registered.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register(tool: McpToolDescriptor<any, any>): void {
+    if (this.tools.has(tool.id)) {
+      throw new FeatureRegistryError(
+        `MCP tool '${tool.id}' is already registered`,
+        "DUPLICATE_ID",
+        tool.id,
+      );
+    }
+    if (!tool.id || !tool.namespace || !tool.name) {
+      throw new FeatureRegistryError(
+        `Tool descriptor must have id, namespace, and name`,
+        "INVALID_DESCRIPTOR",
+        tool.id,
+      );
+    }
+
+    this.tools.set(tool.id, tool);
+
+    // Also register with the underlying FeatureRegistry for dependency tracking
+    this.featureRegistry.register({
+      id: tool.id,
+      version: "1.0.0",
+      dependsOn: [],
+      provides: [`mcp-tool:${tool.namespace}`],
+      metadata: { namespace: tool.namespace, stability: tool.stability },
+    });
+  }
+
+  /** Returns the tool descriptor or `undefined`. */
+  lookup(id: string): McpToolDescriptor | undefined {
+    return this.tools.get(id);
+  }
+
+  /**
+   * Returns the tool descriptor.
+   * @throws {FeatureRegistryError} NOT_FOUND if not registered.
+   */
+  require(id: string): McpToolDescriptor {
+    const tool = this.tools.get(id);
+    if (tool === undefined) {
+      throw new FeatureRegistryError(
+        `MCP tool '${id}' is not registered`,
+        "NOT_FOUND",
+        id,
+      );
+    }
+    return tool;
+  }
+
+  /** Returns all registered tool descriptors. */
+  list(): McpToolDescriptor[] {
+    return [...this.tools.values()];
+  }
+
+  /** Returns all tools in a given namespace. */
+  listByNamespace(namespace: string): McpToolDescriptor[] {
+    return [...this.tools.values()].filter((t) => t.namespace === namespace);
+  }
+
+  /** Returns all registered namespaces. */
+  namespaces(): string[] {
+    return [...new Set([...this.tools.values()].map((t) => t.namespace))];
+  }
+
+  /**
+   * Generate the MCP capabilities manifest for the current tool set.
+   * Groups tools by namespace and surfaces stability information.
+   */
+  getCapabilities(options?: {
+    mcpVersion?: string;
+    schemaVersion?: string;
+    legacyAliasesEnabled?: boolean;
+  }): McpCapabilitiesManifest {
+    const {
+      mcpVersion = "2.0",
+      schemaVersion = new Date().toISOString().slice(0, 10),
+      legacyAliasesEnabled = true,
+    } = options ?? {};
+
+    const nsByName = new Map<string, McpToolDescriptor[]>();
+    for (const tool of this.tools.values()) {
+      const group = nsByName.get(tool.namespace) ?? [];
+      group.push(tool);
+      nsByName.set(tool.namespace, group);
+    }
+
+    const toolNamespaces = [...nsByName.entries()].map(([ns, tools]) => ({
+      namespace: ns,
+      version: "1.0",
+      tools: tools.map((t) => t.id),
+      ownerTeam: "ficecal-core",
+      stability: tools.some((t) => t.stability === "experimental")
+        ? "experimental"
+        : tools.some((t) => t.stability === "beta")
+          ? "beta"
+          : "stable",
+    }));
+
+    return {
+      mcpVersion,
+      schemaVersion,
+      toolNamespaces,
+      compatibility: {
+        legacyAliasesEnabled,
+        aliasNamespace: "finops",
+        parityFixtureVersion: "1.0",
+      },
+      featureFlags: ["mcp_v2", "ficecal_economics_tools"],
+    };
+  }
+}

--- a/packages/mcp-tooling/src/tools/cost-estimate.ts
+++ b/packages/mcp-tooling/src/tools/cost-estimate.ts
@@ -1,0 +1,160 @@
+import { computeAiCost } from "@ficecal/ai-token-economics";
+import type { AiCostInput } from "@ficecal/ai-token-economics";
+import type { McpToolDescriptor, McpToolResult } from "../types.js";
+
+// ─── Input / Output ──────────────────────────────────────────────────────────
+
+export interface CostEstimateInput {
+  pricingUnit: string;
+  // Token inputs
+  inputTokens?: number;
+  outputTokens?: number;
+  inputPricePerUnit?: string;
+  outputPricePerUnit?: string;
+  // Image inputs
+  imageCount?: number;
+  pricePerImage?: string;
+  resolutionMultiplier?: string;
+  stepsMultiplier?: string;
+  // Request inputs
+  requestCount?: number;
+  pricePerRequest?: string;
+  // Time inputs
+  durationSeconds?: number;
+  pricePerSecond?: string;
+  // Common
+  currency: string;
+  period: string;
+}
+
+export interface CostEstimateOutput {
+  totalCost: string;
+  currency: string;
+  period: string;
+  pricingUnit: string;
+  breakdown: Array<{ label: string; quantity: number; unitCost: string; subtotal: string }>;
+  formulasApplied: string[];
+}
+
+// ─── Tool descriptor ─────────────────────────────────────────────────────────
+
+export const costEstimateTool: McpToolDescriptor<CostEstimateInput, CostEstimateOutput> = {
+  id: "economics.estimate.cost",
+  name: "Cost Estimate",
+  description:
+    "Compute AI inference cost for any pricing unit (per_token, per_1k_tokens, per_1m_tokens, per_image, per_request, per_second) using Decimal.js precision arithmetic.",
+  namespace: "economics",
+  stability: "stable",
+  inputSchema: {
+    type: "object",
+    properties: {
+      pricingUnit: {
+        type: "string",
+        description: "Pricing unit variant",
+        enum: ["per_token", "per_1k_tokens", "per_1m_tokens", "per_image", "per_request", "per_second"],
+      },
+      inputTokens: { type: "number", description: "Number of input/prompt tokens" },
+      outputTokens: { type: "number", description: "Number of output/completion tokens" },
+      inputPricePerUnit: { type: "string", description: "Price per unit for input tokens (decimal string)" },
+      outputPricePerUnit: { type: "string", description: "Price per unit for output tokens (decimal string)" },
+      imageCount: { type: "number", description: "Number of images generated" },
+      pricePerImage: { type: "string", description: "Base price per image (decimal string)" },
+      resolutionMultiplier: { type: "string", description: "Resolution tier multiplier (default '1')" },
+      stepsMultiplier: { type: "string", description: "Diffusion steps multiplier (default '1')" },
+      requestCount: { type: "number", description: "Number of API requests" },
+      pricePerRequest: { type: "string", description: "Price per API request (decimal string)" },
+      durationSeconds: { type: "number", description: "Total inference duration in seconds" },
+      pricePerSecond: { type: "string", description: "Price per second (decimal string)" },
+      currency: { type: "string", description: "ISO 4217 currency code (e.g. USD)" },
+      period: {
+        type: "string",
+        description: "Billing period",
+        enum: ["hourly", "daily", "weekly", "monthly", "quarterly", "annual"],
+      },
+    },
+    required: ["pricingUnit", "currency", "period"],
+  },
+
+  handler: async (envelope) => {
+    const { input, context } = envelope;
+    const warnings: string[] = [];
+
+    // Build typed AiCostInput from the loose envelope input
+    let aiInput: AiCostInput;
+
+    if (
+      input.pricingUnit === "per_token" ||
+      input.pricingUnit === "per_1k_tokens" ||
+      input.pricingUnit === "per_1m_tokens"
+    ) {
+      if (input.inputPricePerUnit === undefined) {
+        warnings.push("inputPricePerUnit not provided — defaulting to '0'");
+      }
+      aiInput = {
+        pricingUnit: input.pricingUnit as "per_token" | "per_1k_tokens" | "per_1m_tokens",
+        inputTokens: input.inputTokens ?? 0,
+        outputTokens: input.outputTokens ?? 0,
+        inputPricePerUnit: input.inputPricePerUnit ?? "0",
+        ...(input.outputPricePerUnit !== undefined
+          ? { outputPricePerUnit: input.outputPricePerUnit }
+          : {}),
+        currency: input.currency,
+        period: input.period as AiCostInput["period"],
+      };
+    } else if (input.pricingUnit === "per_image") {
+      aiInput = {
+        pricingUnit: "per_image",
+        imageCount: input.imageCount ?? 0,
+        pricePerImage: input.pricePerImage ?? "0",
+        ...(input.resolutionMultiplier !== undefined
+          ? { resolutionMultiplier: input.resolutionMultiplier }
+          : {}),
+        ...(input.stepsMultiplier !== undefined
+          ? { stepsMultiplier: input.stepsMultiplier }
+          : {}),
+        currency: input.currency,
+        period: input.period as AiCostInput["period"],
+      };
+    } else if (input.pricingUnit === "per_request") {
+      aiInput = {
+        pricingUnit: "per_request",
+        requestCount: input.requestCount ?? 0,
+        pricePerRequest: input.pricePerRequest ?? "0",
+        currency: input.currency,
+        period: input.period as AiCostInput["period"],
+      };
+    } else {
+      // per_second
+      aiInput = {
+        pricingUnit: "per_second",
+        durationSeconds: input.durationSeconds ?? 0,
+        pricePerSecond: input.pricePerSecond ?? "0",
+        currency: input.currency,
+        period: input.period as AiCostInput["period"],
+      };
+    }
+
+    const result = computeAiCost(aiInput);
+    warnings.push(...result.warnings);
+
+    const output: CostEstimateOutput = {
+      totalCost: result.totalCost,
+      currency: result.currency,
+      period: result.period,
+      pricingUnit: result.pricingUnit,
+      breakdown: result.breakdown,
+      formulasApplied: result.formulasApplied,
+    };
+
+    const toolResult: McpToolResult<CostEstimateOutput> = {
+      output,
+      toolId: costEstimateTool.id,
+      executedAt: result.computedAt,
+      requestId: context.requestId,
+      warnings,
+      appliedIds: result.formulasApplied,
+    };
+
+    return toolResult;
+  },
+};

--- a/packages/mcp-tooling/src/tools/health-score-query.ts
+++ b/packages/mcp-tooling/src/tools/health-score-query.ts
@@ -1,0 +1,118 @@
+import { computeHealthScore } from "@ficecal/health-score";
+import { computeRecommendations } from "@ficecal/recommendation-module";
+import type { HealthSignal } from "@ficecal/health-score";
+import type { McpToolDescriptor, McpToolResult } from "../types.js";
+
+// ─── Input / Output ──────────────────────────────────────────────────────────
+
+export interface HealthSignalInput {
+  id: string;
+  category: string;
+  label: string;
+  score: number;
+  severity: string;
+  rationale: string;
+  recommendation?: string;
+}
+
+export interface WeightedSignalInput {
+  signal: HealthSignalInput;
+  weight: number;
+}
+
+export interface HealthScoreQueryInput {
+  signals: WeightedSignalInput[];
+  audiences?: string[];
+}
+
+export interface HealthScoreQueryOutput {
+  weightedScore: number;
+  overallSeverity: string;
+  computedAt: string;
+  warnings: string[];
+  recommendations: Array<{
+    id: string;
+    audience: string;
+    priority: string;
+    title: string;
+    action: string;
+  }>;
+}
+
+// ─── Tool descriptor ─────────────────────────────────────────────────────────
+
+export const healthScoreQueryTool: McpToolDescriptor<HealthScoreQueryInput, HealthScoreQueryOutput> = {
+  id: "health.score.query",
+  name: "Health Score Query",
+  description:
+    "Compute a weighted aggregate health score from a set of health signals, then derive audience-aware recommendations for any signals below threshold.",
+  namespace: "health",
+  stability: "stable",
+  inputSchema: {
+    type: "object",
+    properties: {
+      signals: {
+        type: "array",
+        description: "Array of weighted health signals to evaluate",
+      },
+      audiences: {
+        type: "array",
+        description: "Audience personas to filter recommendations for (default: all)",
+      },
+    },
+    required: ["signals"],
+  },
+
+  handler: async (envelope) => {
+    const { input, context } = envelope;
+
+    // Cast the loose input signals to the typed HealthSignal interface
+    const typedSignals: HealthSignal[] = input.signals.map((ws) => ({
+      id: ws.signal.id,
+      category: ws.signal.category as HealthSignal["category"],
+      label: ws.signal.label,
+      score: ws.signal.score,
+      severity: ws.signal.severity as HealthSignal["severity"],
+      rationale: ws.signal.rationale,
+      ...(ws.signal.recommendation !== undefined
+        ? { recommendation: ws.signal.recommendation }
+        : {}),
+    }));
+
+    const weightedSignals = input.signals.map((ws, i) => ({
+      signal: typedSignals[i]!,
+      weight: ws.weight,
+    }));
+
+    const healthResult = computeHealthScore(weightedSignals);
+
+    const recResult = computeRecommendations(typedSignals, {
+      audiences: input.audiences as Parameters<typeof computeRecommendations>[1]["audiences"],
+    });
+
+    const output: HealthScoreQueryOutput = {
+      weightedScore: Number(healthResult.weightedScore.toFixed(2)),
+      overallSeverity: healthResult.overallSeverity,
+      computedAt: healthResult.computedAt,
+      warnings: [...healthResult.warnings, ...recResult.warnings],
+      recommendations: recResult.recommendations.map((r) => ({
+        id: r.id,
+        audience: r.audience,
+        priority: r.priority,
+        title: r.title,
+        action: r.action,
+      })),
+    };
+
+    const result: McpToolResult<HealthScoreQueryOutput> = {
+      output,
+      toolId: healthScoreQueryTool.id,
+      executedAt: healthResult.computedAt,
+      requestId: context.requestId,
+      warnings: output.warnings,
+      appliedIds: ["health.weightedScore", "recommendation.ruleEngine"],
+    };
+
+    return result;
+  },
+};

--- a/packages/mcp-tooling/src/tools/period-normalize.ts
+++ b/packages/mcp-tooling/src/tools/period-normalize.ts
@@ -1,0 +1,74 @@
+import { normalizePeriod } from "@ficecal/core-economics";
+import type { Period } from "@ficecal/core-economics";
+import type { McpToolDescriptor, McpToolResult } from "../types.js";
+
+// ─── Input / Output ──────────────────────────────────────────────────────────
+
+export interface PeriodNormalizeInput {
+  amount: string;
+  fromPeriod: string;
+  toPeriod: string;
+}
+
+export interface PeriodNormalizeOutput {
+  normalizedAmount: string;
+  fromPeriod: string;
+  toPeriod: string;
+  formulasApplied: string[];
+}
+
+// ─── Tool descriptor ─────────────────────────────────────────────────────────
+
+export const periodNormalizeTool: McpToolDescriptor<PeriodNormalizeInput, PeriodNormalizeOutput> = {
+  id: "economics.period.normalize",
+  name: "Period Normalize",
+  description:
+    "Convert a cost amount between billing periods (e.g. monthly → annual) using exact Decimal.js ratio arithmetic. All supported periods: hourly, daily, weekly, monthly, quarterly, annual.",
+  namespace: "economics",
+  stability: "stable",
+  inputSchema: {
+    type: "object",
+    properties: {
+      amount: { type: "string", description: "Source amount as a decimal string (e.g. '1500.00')" },
+      fromPeriod: {
+        type: "string",
+        description: "Source billing period",
+        enum: ["hourly", "daily", "weekly", "monthly", "quarterly", "annual"],
+      },
+      toPeriod: {
+        type: "string",
+        description: "Target billing period",
+        enum: ["hourly", "daily", "weekly", "monthly", "quarterly", "annual"],
+      },
+    },
+    required: ["amount", "fromPeriod", "toPeriod"],
+  },
+
+  handler: async (envelope) => {
+    const { input, context } = envelope;
+
+    const normalized = normalizePeriod(
+      input.amount,
+      input.fromPeriod as Period,
+      input.toPeriod as Period,
+    );
+
+    const output: PeriodNormalizeOutput = {
+      normalizedAmount: normalized,
+      fromPeriod: input.fromPeriod,
+      toPeriod: input.toPeriod,
+      formulasApplied: ["period.normalize"],
+    };
+
+    const result: McpToolResult<PeriodNormalizeOutput> = {
+      output,
+      toolId: periodNormalizeTool.id,
+      executedAt: new Date().toISOString(),
+      requestId: context.requestId,
+      warnings: [],
+      appliedIds: ["period.normalize"],
+    };
+
+    return result;
+  },
+};

--- a/packages/mcp-tooling/src/types.ts
+++ b/packages/mcp-tooling/src/types.ts
@@ -1,0 +1,121 @@
+// ─── MCP protocol context (compatible with services/mcp/src/mcp/types.ts) ───
+
+export type McpMode = "quick" | "operator" | "architect";
+export type McpActor = "human" | "agent" | "system";
+
+export interface McpTimeRange {
+  start: string; // ISO date
+  end: string;   // ISO date
+  tz: string;    // IANA timezone
+}
+
+export interface McpContractVersions {
+  mcp: string;
+  tool: string;
+  fixture: string;
+}
+
+export interface McpRequestContext {
+  requestId: string;
+  traceId: string;
+  mode: McpMode;
+  workspaceId: string;
+  actor: McpActor;
+  timeRange: McpTimeRange;
+  contractVersions: McpContractVersions;
+  featureFlags: string[];
+}
+
+export interface McpToolEnvelope<TInput> {
+  context: McpRequestContext;
+  input: TInput;
+}
+
+// ─── Tool descriptor ──────────────────────────────────────────────────────────
+
+/**
+ * JSON Schema-compatible type for documenting tool input shapes.
+ * Not a full JSON Schema implementation — just enough for tooling metadata.
+ */
+export interface McpToolInputSchema {
+  type: "object";
+  properties: Record<string, { type: string; description: string; enum?: string[] }>;
+  required: string[];
+}
+
+/**
+ * Descriptor for a registerable MCP tool.
+ *
+ * Tools are the units of capability exposed over the MCP protocol.
+ * Each tool is registered in the McpToolRegistry and surfaced via
+ * the capabilities endpoint.
+ */
+export interface McpToolDescriptor<TInput = unknown, TOutput = unknown> {
+  /** Unique tool id. Convention: `<namespace>.<verb>.<noun>` */
+  id: string;
+
+  /** Human-readable tool name. */
+  name: string;
+
+  /** Description shown to agents consuming the MCP capabilities manifest. */
+  description: string;
+
+  /** Namespace grouping (e.g. "economics", "billing", "health"). */
+  namespace: string;
+
+  /** Stability level — drives capability manifest surfacing. */
+  stability: "stable" | "beta" | "experimental";
+
+  /** JSON Schema for the tool's input payload. */
+  inputSchema: McpToolInputSchema;
+
+  /**
+   * Pure handler function: takes an envelope (context + input) and
+   * returns a typed result. Injected at registration time.
+   */
+  handler: (envelope: McpToolEnvelope<TInput>) => Promise<McpToolResult<TOutput>>;
+}
+
+// ─── Tool result ─────────────────────────────────────────────────────────────
+
+export interface McpToolResult<TOutput> {
+  /** The tool output payload. */
+  output: TOutput;
+
+  /** Traceability: which tool produced this result. */
+  toolId: string;
+
+  /** ISO timestamp of execution. */
+  executedAt: string;
+
+  /** Mirrors the requestId from the envelope context for correlation. */
+  requestId: string;
+
+  /** Non-fatal warnings produced during execution. */
+  warnings: string[];
+
+  /** Formula or rule IDs applied (for auditability). */
+  appliedIds: string[];
+}
+
+// ─── Capabilities manifest ───────────────────────────────────────────────────
+
+export interface McpToolNamespaceManifest {
+  namespace: string;
+  version: string;
+  tools: string[]; // tool ids
+  ownerTeam: string;
+  stability: string;
+}
+
+export interface McpCapabilitiesManifest {
+  mcpVersion: string;
+  schemaVersion: string;
+  toolNamespaces: McpToolNamespaceManifest[];
+  compatibility: {
+    legacyAliasesEnabled: boolean;
+    aliasNamespace: string;
+    parityFixtureVersion: string;
+  };
+  featureFlags: string[];
+}

--- a/packages/mcp-tooling/tests/tool-registry.test.ts
+++ b/packages/mcp-tooling/tests/tool-registry.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { McpToolRegistry } from "../src/tool-registry.js";
+import { FeatureRegistryError } from "@ficecal/feature-registry";
+import { costEstimateTool, healthScoreQueryTool, periodNormalizeTool } from "../src/index.js";
+
+describe("McpToolRegistry", () => {
+  let registry: McpToolRegistry;
+
+  beforeEach(() => {
+    registry = new McpToolRegistry();
+  });
+
+  // ── Registration ────────────────────────────────────────────────────────
+
+  describe("register", () => {
+    it("registers a tool successfully", () => {
+      registry.register(costEstimateTool);
+      expect(registry.lookup(costEstimateTool.id)).toBeDefined();
+    });
+
+    it("throws DUPLICATE_ID when registering same tool twice", () => {
+      registry.register(costEstimateTool);
+      expect(() => registry.register(costEstimateTool)).toThrowError(FeatureRegistryError);
+      try {
+        registry.register(costEstimateTool);
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("DUPLICATE_ID");
+      }
+    });
+
+    it("registers all three built-in tools without error", () => {
+      registry.register(costEstimateTool);
+      registry.register(healthScoreQueryTool);
+      registry.register(periodNormalizeTool);
+      expect(registry.list()).toHaveLength(3);
+    });
+  });
+
+  // ── Lookup ──────────────────────────────────────────────────────────────
+
+  describe("lookup / require", () => {
+    it("lookup returns undefined for unknown id", () => {
+      expect(registry.lookup("unknown.tool")).toBeUndefined();
+    });
+
+    it("require throws NOT_FOUND for unknown id", () => {
+      try {
+        registry.require("unknown.tool");
+      } catch (e) {
+        expect((e as FeatureRegistryError).code).toBe("NOT_FOUND");
+      }
+    });
+
+    it("require returns the tool descriptor", () => {
+      registry.register(costEstimateTool);
+      const tool = registry.require(costEstimateTool.id);
+      expect(tool.id).toBe(costEstimateTool.id);
+      expect(tool.namespace).toBe("economics");
+    });
+  });
+
+  // ── Namespace queries ────────────────────────────────────────────────────
+
+  describe("listByNamespace", () => {
+    it("returns tools in the economics namespace", () => {
+      registry.register(costEstimateTool);
+      registry.register(healthScoreQueryTool);
+      registry.register(periodNormalizeTool);
+
+      const econ = registry.listByNamespace("economics");
+      expect(econ.map((t) => t.id)).toContain(costEstimateTool.id);
+      expect(econ.map((t) => t.id)).toContain(periodNormalizeTool.id);
+      expect(econ.map((t) => t.id)).not.toContain(healthScoreQueryTool.id);
+    });
+
+    it("returns tools in the health namespace", () => {
+      registry.register(healthScoreQueryTool);
+      const health = registry.listByNamespace("health");
+      expect(health).toHaveLength(1);
+      expect(health[0]?.id).toBe(healthScoreQueryTool.id);
+    });
+
+    it("returns empty array for unknown namespace", () => {
+      expect(registry.listByNamespace("billing")).toHaveLength(0);
+    });
+  });
+
+  describe("namespaces", () => {
+    it("returns all unique namespaces", () => {
+      registry.register(costEstimateTool);
+      registry.register(healthScoreQueryTool);
+      registry.register(periodNormalizeTool);
+
+      const ns = registry.namespaces();
+      expect(ns).toContain("economics");
+      expect(ns).toContain("health");
+    });
+
+    it("returns empty array on empty registry", () => {
+      expect(registry.namespaces()).toHaveLength(0);
+    });
+  });
+
+  // ── Capabilities manifest ────────────────────────────────────────────────
+
+  describe("getCapabilities", () => {
+    it("returns a valid capabilities manifest", () => {
+      registry.register(costEstimateTool);
+      registry.register(healthScoreQueryTool);
+      registry.register(periodNormalizeTool);
+
+      const caps = registry.getCapabilities();
+      expect(caps.mcpVersion).toBe("2.0");
+      expect(caps.toolNamespaces.length).toBeGreaterThan(0);
+    });
+
+    it("includes economics namespace with both tools", () => {
+      registry.register(costEstimateTool);
+      registry.register(periodNormalizeTool);
+
+      const caps = registry.getCapabilities();
+      const econNs = caps.toolNamespaces.find((ns) => ns.namespace === "economics");
+      expect(econNs).toBeDefined();
+      expect(econNs!.tools).toContain(costEstimateTool.id);
+      expect(econNs!.tools).toContain(periodNormalizeTool.id);
+    });
+
+    it("includes health namespace", () => {
+      registry.register(healthScoreQueryTool);
+      const caps = registry.getCapabilities();
+      const healthNs = caps.toolNamespaces.find((ns) => ns.namespace === "health");
+      expect(healthNs).toBeDefined();
+    });
+
+    it("marks stable tools as stable in capabilities", () => {
+      registry.register(costEstimateTool);
+      const caps = registry.getCapabilities();
+      const econNs = caps.toolNamespaces.find((ns) => ns.namespace === "economics");
+      expect(econNs!.stability).toBe("stable");
+    });
+
+    it("includes ficecal feature flag", () => {
+      const caps = registry.getCapabilities();
+      expect(caps.featureFlags).toContain("ficecal_economics_tools");
+    });
+
+    it("returns empty toolNamespaces when registry is empty", () => {
+      const caps = registry.getCapabilities();
+      expect(caps.toolNamespaces).toHaveLength(0);
+    });
+  });
+});

--- a/packages/mcp-tooling/tests/tools.test.ts
+++ b/packages/mcp-tooling/tests/tools.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import { costEstimateTool, healthScoreQueryTool, periodNormalizeTool } from "../src/index.js";
+import type { McpRequestContext } from "../src/types.js";
+
+// ─── Context fixture ──────────────────────────────────────────────────────────
+
+function makeContext(overrides?: Partial<McpRequestContext>): McpRequestContext {
+  return {
+    requestId: "test-req-001",
+    traceId: "test-trace-001",
+    mode: "operator",
+    workspaceId: "ws-test",
+    actor: "system",
+    timeRange: { start: "2026-01-01", end: "2026-01-31", tz: "UTC" },
+    contractVersions: { mcp: "2.0", tool: "1.0", fixture: "1.0" },
+    featureFlags: [],
+    ...overrides,
+  };
+}
+
+// ─── costEstimateTool ─────────────────────────────────────────────────────────
+
+describe("costEstimateTool (economics.estimate.cost)", () => {
+  it("has correct id and namespace", () => {
+    expect(costEstimateTool.id).toBe("economics.estimate.cost");
+    expect(costEstimateTool.namespace).toBe("economics");
+    expect(costEstimateTool.stability).toBe("stable");
+  });
+
+  it("computes per_1m_tokens cost correctly", async () => {
+    const result = await costEstimateTool.handler({
+      context: makeContext(),
+      input: {
+        pricingUnit: "per_1m_tokens",
+        inputTokens: 1_000_000,
+        outputTokens: 500_000,
+        inputPricePerUnit: "0.50",
+        outputPricePerUnit: "1.50",
+        currency: "USD",
+        period: "monthly",
+      },
+    });
+    expect(result.output.totalCost).toBe("1.2500000000");
+    expect(result.requestId).toBe("test-req-001");
+    expect(result.toolId).toBe("economics.estimate.cost");
+  });
+
+  it("computes per_image cost correctly", async () => {
+    const result = await costEstimateTool.handler({
+      context: makeContext(),
+      input: {
+        pricingUnit: "per_image",
+        imageCount: 100,
+        pricePerImage: "0.080",
+        currency: "USD",
+        period: "monthly",
+      },
+    });
+    expect(result.output.totalCost).toBe("8.0000000000");
+    expect(result.output.pricingUnit).toBe("per_image");
+  });
+
+  it("computes per_request cost correctly", async () => {
+    const result = await costEstimateTool.handler({
+      context: makeContext(),
+      input: {
+        pricingUnit: "per_request",
+        requestCount: 1000,
+        pricePerRequest: "0.0005",
+        currency: "USD",
+        period: "monthly",
+      },
+    });
+    expect(result.output.totalCost).toBe("0.5000000000");
+  });
+
+  it("computes per_second cost correctly", async () => {
+    const result = await costEstimateTool.handler({
+      context: makeContext(),
+      input: {
+        pricingUnit: "per_second",
+        durationSeconds: 3600,
+        pricePerSecond: "0.00010",
+        currency: "USD",
+        period: "monthly",
+      },
+    });
+    expect(result.output.totalCost).toBe("0.3600000000");
+  });
+
+  it("includes formulasApplied in output", async () => {
+    const result = await costEstimateTool.handler({
+      context: makeContext(),
+      input: {
+        pricingUnit: "per_token",
+        inputTokens: 100,
+        outputTokens: 50,
+        inputPricePerUnit: "0.000010",
+        currency: "USD",
+        period: "monthly",
+      },
+    });
+    expect(result.appliedIds.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── healthScoreQueryTool ─────────────────────────────────────────────────────
+
+describe("healthScoreQueryTool (health.score.query)", () => {
+  it("has correct id and namespace", () => {
+    expect(healthScoreQueryTool.id).toBe("health.score.query");
+    expect(healthScoreQueryTool.namespace).toBe("health");
+    expect(healthScoreQueryTool.stability).toBe("stable");
+  });
+
+  it("computes health score from signals", async () => {
+    const result = await healthScoreQueryTool.handler({
+      context: makeContext(),
+      input: {
+        signals: [
+          {
+            signal: {
+              id: "sig-1",
+              category: "pricing-freshness",
+              label: "Pricing freshness",
+              score: 80,
+              severity: "ok",
+              rationale: "Pricing is fresh.",
+            },
+            weight: 1,
+          },
+          {
+            signal: {
+              id: "sig-2",
+              category: "budget-adherence",
+              label: "Budget adherence",
+              score: 60,
+              severity: "warning",
+              rationale: "Spend at 88% of budget.",
+            },
+            weight: 2,
+          },
+        ],
+      },
+    });
+    expect(result.output.weightedScore).toBeTypeOf("number");
+    expect(result.output.weightedScore).toBeGreaterThan(0);
+    expect(["ok", "warning", "critical"]).toContain(result.output.overallSeverity);
+    expect(result.requestId).toBe("test-req-001");
+  });
+
+  it("returns recommendations for warning-level signals", async () => {
+    const result = await healthScoreQueryTool.handler({
+      context: makeContext(),
+      input: {
+        signals: [
+          {
+            signal: {
+              id: "sig-budget",
+              category: "budget-adherence",
+              label: "Budget",
+              score: 40,
+              severity: "critical",
+              rationale: "Budget exceeded.",
+            },
+            weight: 1,
+          },
+        ],
+      },
+    });
+    expect(result.output.recommendations.length).toBeGreaterThan(0);
+    const priorities = result.output.recommendations.map((r) => r.priority);
+    expect(priorities).toContain("critical");
+  });
+
+  it("returns no recommendations when all signals are ok", async () => {
+    const result = await healthScoreQueryTool.handler({
+      context: makeContext(),
+      input: {
+        signals: [
+          {
+            signal: {
+              id: "sig-ok",
+              category: "cost-efficiency",
+              label: "Cost efficiency",
+              score: 100,
+              severity: "ok",
+              rationale: "All good.",
+            },
+            weight: 1,
+          },
+        ],
+      },
+    });
+    expect(result.output.recommendations).toHaveLength(0);
+  });
+});
+
+// ─── periodNormalizeTool ──────────────────────────────────────────────────────
+
+describe("periodNormalizeTool (economics.period.normalize)", () => {
+  it("has correct id and namespace", () => {
+    expect(periodNormalizeTool.id).toBe("economics.period.normalize");
+    expect(periodNormalizeTool.namespace).toBe("economics");
+    expect(periodNormalizeTool.stability).toBe("stable");
+  });
+
+  it("converts monthly to annual correctly", async () => {
+    const result = await periodNormalizeTool.handler({
+      context: makeContext(),
+      input: { amount: "1000", fromPeriod: "monthly", toPeriod: "annual" },
+    });
+    expect(result.output.normalizedAmount).toBe("12000.0000000000");
+    expect(result.output.fromPeriod).toBe("monthly");
+    expect(result.output.toPeriod).toBe("annual");
+    expect(result.appliedIds).toContain("period.normalize");
+  });
+
+  it("converts annual to monthly correctly", async () => {
+    const result = await periodNormalizeTool.handler({
+      context: makeContext(),
+      input: { amount: "12000", fromPeriod: "annual", toPeriod: "monthly" },
+    });
+    expect(result.output.normalizedAmount).toBe("1000.0000000000");
+  });
+
+  it("converts daily to monthly correctly", async () => {
+    const result = await periodNormalizeTool.handler({
+      context: makeContext(),
+      input: { amount: "100", fromPeriod: "daily", toPeriod: "monthly" },
+    });
+    // 100/day × 30.4375 days/month
+    const val = parseFloat(result.output.normalizedAmount);
+    expect(val).toBeGreaterThan(3000);
+    expect(val).toBeLessThan(3100);
+  });
+
+  it("returns requestId from context", async () => {
+    const result = await periodNormalizeTool.handler({
+      context: makeContext({ requestId: "my-req-xyz" }),
+      input: { amount: "500", fromPeriod: "monthly", toPeriod: "annual" },
+    });
+    expect(result.requestId).toBe("my-req-xyz");
+  });
+});

--- a/packages/mcp-tooling/tsconfig.json
+++ b/packages/mcp-tooling/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,37 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.15)
 
+  packages/mcp-tooling:
+    dependencies:
+      '@ficecal/ai-token-economics':
+        specifier: workspace:*
+        version: link:../ai-token-economics
+      '@ficecal/core-economics':
+        specifier: workspace:*
+        version: link:../core-economics
+      '@ficecal/feature-registry':
+        specifier: workspace:*
+        version: link:../feature-registry
+      '@ficecal/health-score':
+        specifier: workspace:*
+        version: link:../health-score
+      '@ficecal/recommendation-module':
+        specifier: workspace:*
+        version: link:../recommendation-module
+      decimal.js:
+        specifier: ^10.4.3
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.15)
+
   packages/recommendation-module:
     dependencies:
       '@ficecal/health-score':


### PR DESCRIPTION
## Summary

- Delivers `@ficecal/mcp-tooling` — MCP tool descriptor contract and registry layer
- **Closes Gap 5**: mcp-tooling moves from `planned` → `active`
- 3 built-in economics/health tools wired to real package implementations
- 32 vitest tests, all passing

## Tools delivered

| Tool ID | Namespace | What it does |
|---------|-----------|-------------|
| `economics.estimate.cost` | economics | All 6 AI pricing units via `computeAiCost` |
| `economics.period.normalize` | economics | Period conversion via `normalizePeriod` |
| `health.score.query` | health | `computeHealthScore` + `computeRecommendations` in one call |

## Architecture

- `McpToolRegistry` wraps `@ficecal/feature-registry` for dependency tracking
- `getCapabilities()` generates a grouped MCP capabilities manifest
- Tool handlers are pure async functions — no side effects, no external I/O
- Protocol types compatible with `services/mcp/src/mcp/types.ts`

## Test plan

- [x] 32/32 vitest tests passing (17 registry + 15 tool execution)
- [x] Per-image gap-1 pricing routed correctly via cost-estimate tool
- [x] Health signals + recommendations combined in single tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the MCP Tooling package (`@ficecal/mcp-tooling`) featuring three new tools: AI inference cost estimation, health score analysis with recommendations, and time period normalization.
  * Added a tool registry system for managing, querying, and listing tools by namespace.

* **Tests**
  * Added comprehensive test suites for the tool registry and all bundled tools.

* **Chores**
  * Configured TypeScript and package dependencies for the new module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->