### PR TITLE
feat(web): Phase 3 Vite + React browser runtime

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FiceCal v2</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ficecal/web",
+  "version": "0.1.0",
+  "description": "FiceCal v2 browser runtime — mode-aware UI wired to economics, health-score, and recommendation packages",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ficecal/ai-token-economics": "workspace:*",
+    "@ficecal/core-economics": "workspace:*",
+    "@ficecal/health-score": "workspace:*",
+    "@ficecal/recommendation-module": "workspace:*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import type { AppMode, SharedContext } from "./types.js";
+import { SharedContextForm } from "./components/SharedContextForm.js";
+import { ModeSelector } from "./components/ModeSelector.js";
+import { CostEstimator } from "./components/CostEstimator.js";
+import { HealthDashboard } from "./components/HealthDashboard.js";
+import { ArchitectPanel } from "./components/ArchitectPanel.js";
+
+const DEFAULT_CONTEXT: SharedContext = {
+  workspaceId: "workspace-finops-001",
+  startDate: "2026-01-01",
+  endDate: "2026-01-31",
+  currency: "MUR",
+};
+
+export function App() {
+  const [mode, setMode] = useState<AppMode>("quick");
+  const [context, setContext] = useState<SharedContext>(DEFAULT_CONTEXT);
+
+  return (
+    <div className="shell">
+      <header className="topbar">
+        <div className="topbar-brand">
+          <p className="eyebrow">FiceCal v2</p>
+          <h1>AI FinOps Platform</h1>
+          <p className="subtitle">
+            Deterministic cost intelligence — decimal-precise, audit-traceable.
+          </p>
+        </div>
+        <div className="mode-status" aria-live="polite">
+          <span className="mode-status-label">Active mode</span>
+          <strong className={`mode-badge mode-badge--${mode}`}>{mode}</strong>
+        </div>
+      </header>
+
+      <ModeSelector activeMode={mode} onModeChange={setMode} />
+
+      <SharedContextForm context={context} onChange={setContext} />
+
+      <main className="content-area" role="main">
+        {mode === "quick" && <CostEstimator context={context} />}
+        {mode === "operator" && <HealthDashboard context={context} />}
+        {mode === "architect" && <ArchitectPanel context={context} />}
+      </main>
+
+      <footer className="footer">
+        <p>
+          FiceCal v2 · Phase 3 bootstrap · All arithmetic via{" "}
+          <code>decimal.js</code> (28dp)
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/components/ArchitectPanel.tsx
+++ b/apps/web/src/components/ArchitectPanel.tsx
@@ -1,0 +1,169 @@
+import type { SharedContext } from "../types.js";
+
+interface Props {
+  context: SharedContext;
+}
+
+const PACKAGE_GRAPH = [
+  {
+    id: "core-economics",
+    status: "active",
+    phase: 1,
+    provides: ["cost-compute", "forex", "period-normalize"],
+    dependsOn: [],
+  },
+  {
+    id: "schemas",
+    status: "active",
+    phase: 0,
+    provides: ["model-pricing-schema"],
+    dependsOn: [],
+  },
+  {
+    id: "integrations",
+    status: "active",
+    phase: 0,
+    provides: ["model-pricing-data"],
+    dependsOn: ["schemas"],
+  },
+  {
+    id: "schemas.normalized-cost-record",
+    status: "active",
+    phase: 1,
+    provides: ["billing-record-contract"],
+    dependsOn: [],
+  },
+  {
+    id: "chart-presentation",
+    status: "active",
+    phase: 2,
+    provides: ["chart-payload"],
+    dependsOn: ["core-economics"],
+  },
+  {
+    id: "health-score",
+    status: "active",
+    phase: 2,
+    provides: ["health-signals"],
+    dependsOn: [],
+  },
+  {
+    id: "recommendation-module",
+    status: "active",
+    phase: 2,
+    provides: ["recommendations"],
+    dependsOn: ["health-score"],
+  },
+  {
+    id: "ai-token-economics",
+    status: "active",
+    phase: 2,
+    provides: ["ai-cost-compute"],
+    dependsOn: ["core-economics"],
+  },
+  {
+    id: "feature-registry",
+    status: "active",
+    phase: 3,
+    provides: ["plugin-registration"],
+    dependsOn: [],
+  },
+  {
+    id: "mcp-tooling",
+    status: "active",
+    phase: 3,
+    provides: ["mcp-tool-registry", "economics-tools"],
+    dependsOn: ["feature-registry", "core-economics", "ai-token-economics", "health-score", "recommendation-module"],
+  },
+];
+
+const PHASE_TAGS: Record<number, string> = {
+  0: "Phase 0 — baseline",
+  1: "Phase 1 — economics kernel",
+  2: "Phase 2 — module hardening",
+  3: "Phase 3 — registry & tooling",
+};
+
+const ADR_ENTRIES = [
+  { id: "ADR-0001", title: "D3-first chart rendering policy", status: "accepted" },
+  { id: "ADR-0002", title: "Decimal.js for all monetary arithmetic", status: "accepted" },
+  { id: "ADR-0003", title: "ForexRateProvider as injected named dependency", status: "accepted" },
+  { id: "ADR-0004", title: "Formula registry for cost computation traceability", status: "accepted" },
+];
+
+export function ArchitectPanel({ context }: Props) {
+  return (
+    <div className="panel-stack">
+      {/* ── Context trace ────────────────────────────────────────── */}
+      <section className="panel" aria-label="Context trace">
+        <h2>Context Trace</h2>
+        <ul className="status-list">
+          <li>
+            <span className="label">Workspace</span>
+            <code>{context.workspaceId}</code>
+          </li>
+          <li>
+            <span className="label">Period</span>
+            <span>{context.startDate} → {context.endDate}</span>
+          </li>
+          <li>
+            <span className="label">Currency</span>
+            <code>{context.currency}</code>
+          </li>
+          <li>
+            <span className="label">Contract version</span>
+            <code>mcp=2.0 / feature-catalog=1.3.0</code>
+          </li>
+          <li>
+            <span className="label">Phase exit tags</span>
+            <span>v2.0.0-phase-0-exit · v2.0.0-phase-1-exit · v2.0.0-phase-2-exit</span>
+          </li>
+        </ul>
+      </section>
+
+      {/* ── Package graph ─────────────────────────────────────────── */}
+      <section className="panel" aria-label="Package dependency graph">
+        <h2>Package Graph</h2>
+        {Object.entries(PHASE_TAGS).map(([phase, label]) => {
+          const pkgs = PACKAGE_GRAPH.filter((p) => p.phase === Number(phase));
+          if (pkgs.length === 0) return null;
+          return (
+            <div key={phase} className="phase-group">
+              <h3 className="phase-label">{label}</h3>
+              <ul className="pkg-list">
+                {pkgs.map((pkg) => (
+                  <li key={pkg.id} className="pkg-item">
+                    <div className="pkg-header">
+                      <code className="pkg-id">{pkg.id}</code>
+                      <span className="status-dot status-dot--active" aria-label="active" />
+                    </div>
+                    <div className="pkg-meta">
+                      <span>Provides: {pkg.provides.join(", ")}</span>
+                      {pkg.dependsOn.length > 0 && (
+                        <span>Depends on: {pkg.dependsOn.join(", ")}</span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </section>
+
+      {/* ── ADRs ──────────────────────────────────────────────────── */}
+      <section className="panel" aria-label="Architecture decision records">
+        <h2>Architecture Decisions</h2>
+        <ul className="adr-list">
+          {ADR_ENTRIES.map((adr) => (
+            <li key={adr.id} className="adr-item">
+              <code>{adr.id}</code>
+              <span>{adr.title}</span>
+              <span className="adr-status">{adr.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/CostEstimator.tsx
+++ b/apps/web/src/components/CostEstimator.tsx
@@ -1,0 +1,299 @@
+import { useState } from "react";
+import { computeAiCost } from "@ficecal/ai-token-economics";
+import type { AiCostInput, AiCostResult } from "@ficecal/ai-token-economics";
+import type { SharedContext, PricingUnit } from "../types.js";
+
+interface Props {
+  context: SharedContext;
+}
+
+const PRICING_UNITS: { value: PricingUnit; label: string }[] = [
+  { value: "per_1m_tokens", label: "Per 1M tokens" },
+  { value: "per_1k_tokens", label: "Per 1K tokens" },
+  { value: "per_token", label: "Per token" },
+  { value: "per_image", label: "Per image" },
+  { value: "per_request", label: "Per request" },
+  { value: "per_second", label: "Per second" },
+];
+
+function buildInput(unit: PricingUnit, fields: Record<string, string>, currency: string): AiCostInput | null {
+  try {
+    if (unit === "per_token" || unit === "per_1k_tokens" || unit === "per_1m_tokens") {
+      return {
+        pricingUnit: unit,
+        inputTokens: Number(fields["inputTokens"] ?? "0"),
+        outputTokens: Number(fields["outputTokens"] ?? "0"),
+        inputPricePerUnit: fields["inputPrice"] ?? "0",
+        outputPricePerUnit: fields["outputPrice"] || undefined,
+        currency,
+        period: "monthly",
+      };
+    }
+    if (unit === "per_image") {
+      return {
+        pricingUnit: "per_image",
+        imageCount: Number(fields["imageCount"] ?? "0"),
+        pricePerImage: fields["pricePerImage"] ?? "0",
+        resolutionMultiplier: fields["resolutionMultiplier"] || undefined,
+        currency,
+        period: "monthly",
+      };
+    }
+    if (unit === "per_request") {
+      return {
+        pricingUnit: "per_request",
+        requestCount: Number(fields["requestCount"] ?? "0"),
+        pricePerRequest: fields["pricePerRequest"] ?? "0",
+        currency,
+        period: "monthly",
+      };
+    }
+    // per_second
+    return {
+      pricingUnit: "per_second",
+      durationSeconds: Number(fields["durationSeconds"] ?? "0"),
+      pricePerSecond: fields["pricePerSecond"] ?? "0",
+      currency,
+      period: "monthly",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function CostEstimator({ context }: Props) {
+  const [unit, setUnit] = useState<PricingUnit>("per_1m_tokens");
+  const [fields, setFields] = useState<Record<string, string>>({
+    inputTokens: "1000000",
+    outputTokens: "500000",
+    inputPrice: "0.50",
+    outputPrice: "1.50",
+    imageCount: "100",
+    pricePerImage: "0.040",
+    resolutionMultiplier: "",
+    requestCount: "1000",
+    pricePerRequest: "0.001",
+    durationSeconds: "3600",
+    pricePerSecond: "0.0001",
+  });
+  const [result, setResult] = useState<AiCostResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function setField(key: string, value: string) {
+    setFields((f) => ({ ...f, [key]: value }));
+  }
+
+  function handleCompute() {
+    setError(null);
+    const input = buildInput(unit, fields, context.currency);
+    if (!input) {
+      setError("Invalid input — check all required fields.");
+      return;
+    }
+    try {
+      setResult(computeAiCost(input));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Computation error");
+    }
+  }
+
+  return (
+    <div className="panel-stack">
+      <section className="panel" aria-label="Cost estimator">
+        <h2>Cost Estimator</h2>
+        <p className="hint">
+          Compute AI inference cost using Decimal.js precision arithmetic.
+        </p>
+
+        <div className="field-row">
+          <label>
+            Pricing unit
+            <select value={unit} onChange={(e) => setUnit(e.target.value as PricingUnit)}>
+              {PRICING_UNITS.map((u) => (
+                <option key={u.value} value={u.value}>
+                  {u.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {(unit === "per_token" || unit === "per_1k_tokens" || unit === "per_1m_tokens") && (
+          <div className="field-grid">
+            <label>
+              Input tokens
+              <input
+                type="number"
+                value={fields["inputTokens"]}
+                onChange={(e) => setField("inputTokens", e.target.value)}
+              />
+            </label>
+            <label>
+              Output tokens
+              <input
+                type="number"
+                value={fields["outputTokens"]}
+                onChange={(e) => setField("outputTokens", e.target.value)}
+              />
+            </label>
+            <label>
+              Input price ({unit === "per_1m_tokens" ? "/1M" : unit === "per_1k_tokens" ? "/1K" : "/token"})
+              <input
+                type="text"
+                value={fields["inputPrice"]}
+                onChange={(e) => setField("inputPrice", e.target.value)}
+              />
+            </label>
+            <label>
+              Output price (optional, defaults to input price)
+              <input
+                type="text"
+                value={fields["outputPrice"]}
+                onChange={(e) => setField("outputPrice", e.target.value)}
+              />
+            </label>
+          </div>
+        )}
+
+        {unit === "per_image" && (
+          <div className="field-grid">
+            <label>
+              Image count
+              <input
+                type="number"
+                value={fields["imageCount"]}
+                onChange={(e) => setField("imageCount", e.target.value)}
+              />
+            </label>
+            <label>
+              Price per image
+              <input
+                type="text"
+                value={fields["pricePerImage"]}
+                onChange={(e) => setField("pricePerImage", e.target.value)}
+              />
+            </label>
+            <label>
+              Resolution multiplier (optional)
+              <input
+                type="text"
+                placeholder="e.g. 1.5"
+                value={fields["resolutionMultiplier"]}
+                onChange={(e) => setField("resolutionMultiplier", e.target.value)}
+              />
+            </label>
+          </div>
+        )}
+
+        {unit === "per_request" && (
+          <div className="field-grid">
+            <label>
+              Request count
+              <input
+                type="number"
+                value={fields["requestCount"]}
+                onChange={(e) => setField("requestCount", e.target.value)}
+              />
+            </label>
+            <label>
+              Price per request
+              <input
+                type="text"
+                value={fields["pricePerRequest"]}
+                onChange={(e) => setField("pricePerRequest", e.target.value)}
+              />
+            </label>
+          </div>
+        )}
+
+        {unit === "per_second" && (
+          <div className="field-grid">
+            <label>
+              Duration (seconds)
+              <input
+                type="number"
+                value={fields["durationSeconds"]}
+                onChange={(e) => setField("durationSeconds", e.target.value)}
+              />
+            </label>
+            <label>
+              Price per second
+              <input
+                type="text"
+                value={fields["pricePerSecond"]}
+                onChange={(e) => setField("pricePerSecond", e.target.value)}
+              />
+            </label>
+          </div>
+        )}
+
+        <div className="action-row">
+          <button type="button" className="action-button" onClick={handleCompute}>
+            Compute cost
+          </button>
+        </div>
+
+        {error && (
+          <div className="error-banner" role="alert">
+            <p>{error}</p>
+          </div>
+        )}
+      </section>
+
+      {result && (
+        <section className="panel result-panel" aria-label="Cost result">
+          <h2>Result</h2>
+          <div className="metric-row">
+            <span>Total cost</span>
+            <strong className="metric-value">
+              {context.currency} {result.totalCost}
+            </strong>
+          </div>
+          <div className="metric-row">
+            <span>Pricing unit</span>
+            <code>{result.pricingUnit}</code>
+          </div>
+          <div className="metric-row">
+            <span>Period</span>
+            <span>{result.period}</span>
+          </div>
+          {result.breakdown.length > 0 && (
+            <>
+              <h3>Breakdown</h3>
+              <table className="breakdown-table">
+                <thead>
+                  <tr>
+                    <th>Item</th>
+                    <th>Quantity</th>
+                    <th>Unit cost</th>
+                    <th>Subtotal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.breakdown.map((line, i) => (
+                    <tr key={i}>
+                      <td>{line.label}</td>
+                      <td>{line.quantity.toLocaleString()}</td>
+                      <td><code>{line.unitCost}</code></td>
+                      <td><strong>{line.subtotal}</strong></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+          {result.warnings.length > 0 && (
+            <div className="warnings">
+              {result.warnings.map((w, i) => (
+                <p key={i} className="warning-line">⚠ {w}</p>
+              ))}
+            </div>
+          )}
+          <p className="formula-trace">
+            Formulas applied: {result.formulasApplied.join(", ")}
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/HealthDashboard.tsx
+++ b/apps/web/src/components/HealthDashboard.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { computeHealthScore } from "@ficecal/health-score";
+import { computeRecommendations } from "@ficecal/recommendation-module";
+import type { HealthSignal, WeightedSignal } from "@ficecal/health-score";
+import type { Recommendation } from "@ficecal/recommendation-module";
+import type { SharedContext } from "../types.js";
+
+interface Props {
+  context: SharedContext;
+}
+
+// Default demo signals so the dashboard is immediately useful
+const DEFAULT_SIGNALS: WeightedSignal[] = [
+  {
+    signal: {
+      id: "pricing-freshness-demo",
+      category: "pricing-freshness",
+      label: "Pricing freshness",
+      score: 75,
+      severity: "warning",
+      rationale: "Pricing data is 12 days old — past the 7-day warning threshold.",
+    },
+    weight: 2,
+  },
+  {
+    signal: {
+      id: "budget-adherence-demo",
+      category: "budget-adherence",
+      label: "Budget adherence",
+      score: 55,
+      severity: "warning",
+      rationale: "Spend at 88% of the monthly budget ceiling.",
+    },
+    weight: 3,
+  },
+  {
+    signal: {
+      id: "model-trust-demo",
+      category: "model-trust",
+      label: "Model trust",
+      score: 90,
+      severity: "ok",
+      rationale: "All active models use verified pricing sources.",
+    },
+    weight: 1,
+  },
+  {
+    signal: {
+      id: "data-completeness-demo",
+      category: "data-completeness",
+      label: "Data completeness",
+      score: 100,
+      severity: "ok",
+      rationale: "All billing records are complete.",
+    },
+    weight: 1,
+  },
+];
+
+const SEVERITY_COLOR: Record<string, string> = {
+  ok: "#16a34a",
+  warning: "#d97706",
+  critical: "#dc2626",
+};
+
+const PRIORITY_COLOR: Record<string, string> = {
+  critical: "#dc2626",
+  high: "#ea580c",
+  medium: "#d97706",
+  low: "#6b7280",
+};
+
+export function HealthDashboard({ context: _context }: Props) {
+  const [signals] = useState<WeightedSignal[]>(DEFAULT_SIGNALS);
+
+  const healthResult = computeHealthScore(signals);
+  const recResult = computeRecommendations(signals.map((ws) => ws.signal));
+
+  const scoreColor =
+    healthResult.overallSeverity === "ok"
+      ? SEVERITY_COLOR["ok"]!
+      : healthResult.overallSeverity === "warning"
+        ? SEVERITY_COLOR["warning"]!
+        : SEVERITY_COLOR["critical"]!;
+
+  return (
+    <div className="panel-stack">
+      {/* ── Score summary ────────────────────────────────────────── */}
+      <section className="panel" aria-label="Health score summary">
+        <h2>Health Score</h2>
+        <div className="score-display">
+          <span
+            className="score-number"
+            style={{ color: scoreColor }}
+            aria-label={`Health score: ${healthResult.weightedScore.toFixed(0)} out of 100`}
+          >
+            {healthResult.weightedScore.toFixed(0)}
+          </span>
+          <span className="score-label">/ 100</span>
+          <span
+            className="severity-badge"
+            style={{ backgroundColor: scoreColor }}
+          >
+            {healthResult.overallSeverity}
+          </span>
+        </div>
+        <p className="hint">
+          Weighted aggregate across {signals.length} signals · computed{" "}
+          {new Date(healthResult.computedAt).toLocaleTimeString()}
+        </p>
+      </section>
+
+      {/* ── Signal breakdown ─────────────────────────────────────── */}
+      <section className="panel" aria-label="Signal breakdown">
+        <h2>Signals</h2>
+        <ul className="signal-list">
+          {signals.map(({ signal }: { signal: HealthSignal }) => (
+            <li key={signal.id} className="signal-item">
+              <div className="signal-header">
+                <span className="signal-label">{signal.label}</span>
+                <span
+                  className="severity-pill"
+                  style={{ backgroundColor: SEVERITY_COLOR[signal.severity] ?? "#6b7280" }}
+                >
+                  {signal.severity}
+                </span>
+                <strong className="signal-score">{signal.score}</strong>
+              </div>
+              <p className="signal-rationale">{signal.rationale}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* ── Recommendations ───────────────────────────────────────── */}
+      <section className="panel" aria-label="Recommendations">
+        <h2>Recommendations</h2>
+        {recResult.recommendations.length === 0 ? (
+          <p className="hint">No actionable recommendations — all signals are healthy.</p>
+        ) : (
+          <ul className="rec-list">
+            {recResult.recommendations.map((rec: Recommendation) => (
+              <li key={rec.id} className="rec-item">
+                <div className="rec-header">
+                  <span
+                    className="priority-badge"
+                    style={{ borderColor: PRIORITY_COLOR[rec.priority] ?? "#6b7280" }}
+                  >
+                    {rec.priority}
+                  </span>
+                  <span className="audience-tag">{rec.audience}</span>
+                  <strong className="rec-title">{rec.title}</strong>
+                </div>
+                <p className="rec-action">{rec.action}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/ModeSelector.tsx
+++ b/apps/web/src/components/ModeSelector.tsx
@@ -1,0 +1,35 @@
+import type { AppMode } from "../types.js";
+
+interface Props {
+  activeMode: AppMode;
+  onModeChange: (mode: AppMode) => void;
+}
+
+const MODES: { id: AppMode; label: string; description: string }[] = [
+  { id: "quick", label: "Quick", description: "Instant cost estimate" },
+  { id: "operator", label: "Operator", description: "Health & recommendations" },
+  { id: "architect", label: "Architect", description: "Traceability & audit" },
+];
+
+export function ModeSelector({ activeMode, onModeChange }: Props) {
+  return (
+    <section className="panel" aria-label="Mode selection">
+      <h2>Mode</h2>
+      <div className="mode-switch" role="tablist" aria-label="UX mode switcher">
+        {MODES.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            role="tab"
+            aria-selected={activeMode === m.id}
+            className={`mode-button${activeMode === m.id ? " is-active" : ""}`}
+            onClick={() => onModeChange(m.id)}
+            title={m.description}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/SharedContextForm.tsx
+++ b/apps/web/src/components/SharedContextForm.tsx
@@ -1,0 +1,62 @@
+import type { SharedContext } from "../types.js";
+
+interface Props {
+  context: SharedContext;
+  onChange: (ctx: SharedContext) => void;
+}
+
+const CURRENCIES = ["USD", "EUR", "GBP", "MUR", "CAD", "AUD", "JPY", "CHF", "INR", "SGD"];
+
+export function SharedContextForm({ context, onChange }: Props) {
+  function update<K extends keyof SharedContext>(key: K, value: SharedContext[K]) {
+    onChange({ ...context, [key]: value });
+  }
+
+  return (
+    <section className="panel" aria-label="Shared context">
+      <h2>Shared Context</h2>
+      <form className="context-grid" noValidate onSubmit={(e) => e.preventDefault()}>
+        <label>
+          Workspace ID
+          <input
+            type="text"
+            value={context.workspaceId}
+            onChange={(e) => update("workspaceId", e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Start date
+          <input
+            type="date"
+            value={context.startDate}
+            onChange={(e) => update("startDate", e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          End date
+          <input
+            type="date"
+            value={context.endDate}
+            onChange={(e) => update("endDate", e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Currency
+          <select
+            value={context.currency}
+            onChange={(e) => update("currency", e.target.value)}
+          >
+            {CURRENCIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </label>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import "./styles.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("Root element #root not found");
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,123 @@
+/* ── Reset & base ─────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --color-bg: #0f172a;
+  --color-surface: #1e293b;
+  --color-surface-2: #273348;
+  --color-border: #334155;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-accent: #38bdf8;
+  --color-ok: #16a34a;
+  --color-warn: #d97706;
+  --color-crit: #dc2626;
+  --radius: 10px;
+  --gap: 1.25rem;
+  --font: "Plus Jakarta Sans", system-ui, sans-serif;
+}
+
+html { font-size: 16px; }
+body { font-family: var(--font); background: var(--color-bg); color: var(--color-text); min-height: 100vh; }
+
+/* ── Shell layout ────────────────────────────────────────────────────────── */
+.shell { max-width: 1100px; margin: 0 auto; padding: 1.5rem; display: flex; flex-direction: column; gap: var(--gap); }
+
+/* ── Topbar ──────────────────────────────────────────────────────────────── */
+.topbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; padding: 1.5rem; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius); }
+.topbar-brand .eyebrow { font-size: 0.75rem; font-weight: 600; color: var(--color-accent); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.25rem; }
+.topbar h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.25rem; }
+.topbar .subtitle { font-size: 0.875rem; color: var(--color-text-muted); }
+.mode-status { display: flex; flex-direction: column; align-items: flex-end; gap: 0.25rem; }
+.mode-status-label { font-size: 0.7rem; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.mode-badge { font-size: 0.8rem; font-weight: 700; padding: 0.2rem 0.6rem; border-radius: 999px; background: var(--color-accent); color: #0f172a; }
+.mode-badge--operator { background: #a78bfa; }
+.mode-badge--architect { background: #fb923c; }
+
+/* ── Panel ───────────────────────────────────────────────────────────────── */
+.panel { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius); padding: 1.5rem; }
+.panel h2 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; color: var(--color-text); }
+.panel h3 { font-size: 0.875rem; font-weight: 600; margin: 1rem 0 0.5rem; color: var(--color-text-muted); }
+.panel-stack { display: flex; flex-direction: column; gap: var(--gap); }
+.hint { font-size: 0.8rem; color: var(--color-text-muted); margin-bottom: 0.75rem; }
+
+/* ── Mode selector ────────────────────────────────────────────────────────── */
+.mode-switch { display: flex; gap: 0.5rem; }
+.mode-button { padding: 0.5rem 1.25rem; border-radius: 999px; border: 1px solid var(--color-border); background: transparent; color: var(--color-text-muted); font-family: var(--font); font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: all 0.15s; }
+.mode-button:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.mode-button.is-active, .mode-button[aria-selected="true"] { background: var(--color-accent); border-color: var(--color-accent); color: #0f172a; font-weight: 700; }
+
+/* ── Context form ────────────────────────────────────────────────────────── */
+.context-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
+label { display: flex; flex-direction: column; gap: 0.35rem; font-size: 0.8rem; font-weight: 500; color: var(--color-text-muted); }
+input, select { background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text); font-family: var(--font); font-size: 0.875rem; padding: 0.4rem 0.6rem; }
+input:focus, select:focus { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
+.action-row { margin-top: 1rem; }
+.action-button { background: var(--color-accent); color: #0f172a; border: none; border-radius: 6px; font-family: var(--font); font-size: 0.875rem; font-weight: 700; padding: 0.55rem 1.25rem; cursor: pointer; transition: opacity 0.15s; }
+.action-button:hover { opacity: 0.85; }
+
+/* ── Field grid (estimator form) ─────────────────────────────────────────── */
+.field-row { margin-bottom: 1rem; }
+.field-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
+
+/* ── Result panel ────────────────────────────────────────────────────────── */
+.result-panel { border-color: var(--color-accent); }
+.metric-row { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid var(--color-border); font-size: 0.875rem; }
+.metric-row:last-of-type { border-bottom: none; }
+.metric-value { font-size: 1.25rem; font-weight: 700; color: var(--color-accent); }
+
+.breakdown-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin-top: 0.5rem; }
+.breakdown-table th, .breakdown-table td { padding: 0.4rem 0.6rem; text-align: left; border-bottom: 1px solid var(--color-border); }
+.breakdown-table th { color: var(--color-text-muted); font-weight: 600; }
+
+.formula-trace { font-size: 0.7rem; color: var(--color-text-muted); margin-top: 0.75rem; }
+.warnings { margin-top: 0.75rem; }
+.warning-line { font-size: 0.8rem; color: var(--color-warn); }
+.error-banner { background: rgba(220, 38, 38, 0.1); border: 1px solid var(--color-crit); border-radius: 6px; padding: 0.75rem 1rem; margin-top: 0.75rem; font-size: 0.875rem; color: var(--color-crit); }
+
+/* ── Health dashboard ───────────────────────────────────────────────────── */
+.score-display { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+.score-number { font-size: 3rem; font-weight: 800; line-height: 1; }
+.score-label { font-size: 1rem; color: var(--color-text-muted); }
+.severity-badge { padding: 0.2rem 0.7rem; border-radius: 999px; font-size: 0.75rem; font-weight: 700; color: #fff; text-transform: uppercase; }
+.severity-pill { padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.7rem; font-weight: 600; color: #fff; }
+.signal-list { list-style: none; display: flex; flex-direction: column; gap: 0.75rem; }
+.signal-item { background: var(--color-surface-2); border-radius: 6px; padding: 0.75rem; }
+.signal-header { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.35rem; }
+.signal-label { font-weight: 600; font-size: 0.875rem; flex: 1; }
+.signal-score { font-weight: 700; font-size: 0.875rem; }
+.signal-rationale { font-size: 0.78rem; color: var(--color-text-muted); }
+
+.rec-list { list-style: none; display: flex; flex-direction: column; gap: 0.75rem; }
+.rec-item { background: var(--color-surface-2); border-radius: 6px; padding: 0.75rem; }
+.rec-header { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.35rem; flex-wrap: wrap; }
+.priority-badge { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; padding: 0.15rem 0.5rem; border-radius: 999px; border: 1.5px solid; }
+.audience-tag { font-size: 0.7rem; color: var(--color-text-muted); background: var(--color-surface); padding: 0.15rem 0.5rem; border-radius: 4px; }
+.rec-title { font-size: 0.875rem; font-weight: 600; flex: 1; }
+.rec-action { font-size: 0.8rem; color: var(--color-text-muted); }
+
+/* ── Architect panel ─────────────────────────────────────────────────────── */
+.status-list { list-style: none; display: flex; flex-direction: column; gap: 0.6rem; }
+.status-list li { display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem; padding: 0.4rem 0; border-bottom: 1px solid var(--color-border); }
+.status-list li:last-child { border-bottom: none; }
+.label { color: var(--color-text-muted); }
+.phase-group { margin-bottom: 1rem; }
+.phase-label { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; color: var(--color-accent); letter-spacing: 0.06em; margin-bottom: 0.5rem; }
+.pkg-list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
+.pkg-item { background: var(--color-surface-2); border-radius: 6px; padding: 0.6rem 0.75rem; }
+.pkg-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.2rem; }
+.pkg-id { font-size: 0.825rem; font-weight: 600; }
+.pkg-meta { font-size: 0.75rem; color: var(--color-text-muted); display: flex; flex-direction: column; gap: 0.1rem; }
+.status-dot--active { width: 8px; height: 8px; border-radius: 50%; background: var(--color-ok); flex-shrink: 0; }
+.adr-list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
+.adr-item { display: flex; align-items: center; gap: 0.75rem; font-size: 0.825rem; padding: 0.4rem 0; border-bottom: 1px solid var(--color-border); }
+.adr-item:last-child { border-bottom: none; }
+.adr-item code { font-size: 0.75rem; color: var(--color-accent); min-width: 80px; }
+.adr-item span:nth-child(2) { flex: 1; }
+.adr-status { font-size: 0.7rem; font-weight: 600; color: var(--color-ok); }
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+.footer { text-align: center; font-size: 0.75rem; color: var(--color-text-muted); padding: 1rem 0; }
+code { font-family: "Fira Code", "Cascadia Code", monospace; font-size: 0.85em; }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,35 @@
+// ─── Shared context ───────────────────────────────────────────────────────────
+
+export type AppMode = "quick" | "operator" | "architect";
+
+export interface SharedContext {
+  workspaceId: string;
+  startDate: string;
+  endDate: string;
+  currency: string;
+}
+
+// ─── Cost estimate form ───────────────────────────────────────────────────────
+
+export type PricingUnit =
+  | "per_token"
+  | "per_1k_tokens"
+  | "per_1m_tokens"
+  | "per_image"
+  | "per_request"
+  | "per_second";
+
+export interface CostEstimateForm {
+  pricingUnit: PricingUnit;
+  inputTokens: string;
+  outputTokens: string;
+  inputPrice: string;
+  outputPrice: string;
+  imageCount: string;
+  pricePerImage: string;
+  resolutionMultiplier: string;
+  requestCount: string;
+  pricePerRequest: string;
+  durationSeconds: string;
+  pricePerSecond: string;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  root: ".",
+  build: {
+    outDir: "dist",
+    sourcemap: true,
+  },
+  resolve: {
+    // Allow TypeScript source imports from workspace packages
+    conditions: ["import", "default"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,43 @@ importers:
 
   .: {}
 
+  apps/web:
+    dependencies:
+      '@ficecal/ai-token-economics':
+        specifier: workspace:*
+        version: link:../../packages/ai-token-economics
+      '@ficecal/core-economics':
+        specifier: workspace:*
+        version: link:../../packages/core-economics
+      '@ficecal/health-score':
+        specifier: workspace:*
+        version: link:../../packages/health-score
+      '@ficecal/recommendation-module':
+        specifier: workspace:*
+        version: link:../../packages/recommendation-module
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@5.4.21(@types/node@22.19.15))
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@22.19.15)
+
   packages/ai-token-economics:
     dependencies:
       '@ficecal/core-economics':
@@ -130,6 +167,89 @@ importers:
         version: 2.1.9(@types/node@22.19.15)
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -269,8 +389,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -397,11 +533,40 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -436,9 +601,22 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  baseline-browser-mapping@2.10.9:
+    resolution: {integrity: sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001780:
+    resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -447,6 +625,12 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -464,6 +648,9 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  electron-to-chromium@1.5.321:
+    resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -471,6 +658,10 @@ packages:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -484,8 +675,32 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -497,6 +712,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-releases@2.0.36:
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -512,9 +730,29 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   siginfo@2.0.0:
@@ -555,6 +793,12 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -622,10 +866,125 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -696,7 +1055,26 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -773,11 +1151,55 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.15))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -821,7 +1243,19 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  baseline-browser-mapping@2.10.9: {}
+
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.10.9
+      caniuse-lite: 1.0.30001780
+      electron-to-chromium: 1.5.321
+      node-releases: 2.0.36
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
   cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001780: {}
 
   chai@5.3.3:
     dependencies:
@@ -833,6 +1267,10 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -840,6 +1278,8 @@ snapshots:
   decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
+
+  electron-to-chromium@1.5.321: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -869,6 +1309,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -878,7 +1320,23 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -887,6 +1345,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  node-releases@2.0.36: {}
 
   pathe@1.1.2: {}
 
@@ -899,6 +1359,18 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   rollup@4.59.0:
     dependencies:
@@ -931,6 +1403,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -952,6 +1430,12 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   vite-node@2.1.9(@types/node@22.19.15):
     dependencies:
@@ -1019,5 +1503,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yallist@3.1.1: {}
 
   zod@3.25.76: {}

--- a/src/features/feature-catalog.json
+++ b/src/features/feature-catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "updatedAt": "2026-03-20",
   "modules": [
     {
@@ -15,7 +15,8 @@
       "path": "packages/feature-registry",
       "dependsOn": [],
       "optional": false,
-      "status": "planned"
+      "status": "active",
+      "note": "Phase 3 — plugin registration contract; FeatureRegistry with Kahn topological sort, diamond-dep + circular-dep detection, capability-based discovery; 27 vitest tests"
     },
     {
       "id": "schemas",
@@ -39,11 +40,28 @@
       "id": "mcp-tooling",
       "path": "packages/mcp-tooling",
       "dependsOn": [
-        "schemas",
-        "feature-registry"
+        "feature-registry",
+        "core-economics",
+        "ai-token-economics",
+        "health-score",
+        "recommendation-module"
       ],
       "optional": false,
-      "status": "planned"
+      "status": "active",
+      "note": "Phase 3 — MCP tool registry + 3 tools (economics.estimate.cost, economics.period.normalize, health.score.query); closes Gap 5; 32 vitest tests"
+    },
+    {
+      "id": "web",
+      "path": "apps/web",
+      "dependsOn": [
+        "ai-token-economics",
+        "core-economics",
+        "health-score",
+        "recommendation-module"
+      ],
+      "optional": false,
+      "status": "active",
+      "note": "Phase 3 — Vite + React browser runtime; CostEstimator (all 6 pricing units), HealthDashboard (signals + recommendations), ArchitectPanel (package graph + ADRs); 64-module Vite build"
     },
     {
       "id": "community.sample-finops-adapter",


### PR DESCRIPTION
## Summary

- Upgrades `apps/web` from static HTML skeleton to a fully wired Vite + React app
- All three mode views (quick/operator/architect) routed and wired to real `@ficecal/*` packages
- 64-module Vite build, 255 kB bundle, 0 TypeScript errors
- `feature-catalog.json` v1.4.0 — feature-registry, mcp-tooling, web all marked `active`

## Views delivered

| Mode | Component | Wired to |
|------|-----------|----------|
| Quick | `CostEstimator` | `@ficecal/ai-token-economics` — all 6 pricing units |
| Operator | `HealthDashboard` | `@ficecal/health-score` + `@ficecal/recommendation-module` |
| Architect | `ArchitectPanel` | Static package graph, ADR list, context trace |

## UX parity preserved

- Three operating modes (quick/operator/architect) ✅
- Shared context continuity across mode switches ✅
- MUR as default currency ✅
- Graceful error handling in CostEstimator ✅

## Test plan

- [x] `vite build` → 64 modules, 255 kB, 0 errors
- [x] `tsc --noEmit` → 0 errors
- [x] No absolute local paths in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)