### PR TITLE
feat(sla-slo-sli-economics): Phase 2 SLA/SLO/SLI reliability economic modeling

### DIFF
--- a/packages/sla-slo-sli-economics/package.json
+++ b/packages/sla-slo-sli-economics/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ficecal/sla-slo-sli-economics",
+  "version": "0.1.0",
+  "description": "FiceCal v2 — economic modeling of SLA/SLO/SLI targets: error budgets, downtime cost, reliability ROI",
+  "type": "module",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ficecal/core-economics": "workspace:*",
+    "decimal.js": "^10.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/sla-slo-sli-economics/src/engine.ts
+++ b/packages/sla-slo-sli-economics/src/engine.ts
@@ -1,0 +1,151 @@
+import { Decimal, toOutputString } from "@ficecal/core-economics";
+import type { Period } from "@ficecal/core-economics";
+import type {
+  SloTarget,
+  ErrorBudgetResult,
+  DowntimeCostInput,
+  DowntimeCostResult,
+  ReliabilityRoiInput,
+  ReliabilityRoiResult,
+} from "./types.js";
+
+// ─── Period minutes ───────────────────────────────────────────────────────────
+
+const MINUTES_IN_PERIOD: Record<Period, string> = {
+  hourly:    "60",
+  daily:     "1440",
+  weekly:    "10080",
+  monthly:   "43829.0625",   // 365.25 / 12 × 24 × 60
+  quarterly: "131487.1875",  // monthly × 3
+  annual:    "525948.75",    // 365.25 × 24 × 60
+};
+
+// ─── Error budget ─────────────────────────────────────────────────────────────
+
+function formatMinutes(minutes: Decimal): string {
+  const totalSecs = minutes.mul(60).toDecimalPlaces(0, Decimal.ROUND_FLOOR);
+  const h = totalSecs.divToInt(3600);
+  const m = totalSecs.minus(h.mul(3600)).divToInt(60);
+  const s = totalSecs.minus(h.mul(3600)).minus(m.mul(60));
+  const parts: string[] = [];
+  if (h.greaterThan(0)) parts.push(`${h}h`);
+  if (m.greaterThan(0)) parts.push(`${m}m`);
+  if (s.greaterThan(0) || parts.length === 0) parts.push(`${s}s`);
+  return parts.join(" ");
+}
+
+export function computeErrorBudget(
+  sloTarget: SloTarget,
+  period: Period,
+  options?: { actualUptimePct?: string },
+): ErrorBudgetResult {
+  const totalMinutes = new Decimal(MINUTES_IN_PERIOD[period]);
+  const downtimePct = new Decimal(100).minus(new Decimal(sloTarget.uptimePct));
+  const allowableDowntimeMinutes = totalMinutes.mul(downtimePct).div(100);
+
+  let errorBudgetConsumedPct: string | undefined;
+  let errorBudgetRemainingPct: string | undefined;
+
+  if (options?.actualUptimePct !== undefined) {
+    const actualDowntimePct = new Decimal(100).minus(new Decimal(options.actualUptimePct));
+    const actualDowntimeMinutes = totalMinutes.mul(actualDowntimePct).div(100);
+    const rawConsumed = allowableDowntimeMinutes.isZero()
+      ? new Decimal(100)
+      : actualDowntimeMinutes.div(allowableDowntimeMinutes).mul(100);
+    const consumed = rawConsumed.lessThan(0)
+      ? new Decimal(0)
+      : rawConsumed.greaterThan(100)
+        ? new Decimal(100)
+        : rawConsumed;
+    const remaining = new Decimal(100).minus(consumed);
+    errorBudgetConsumedPct = toOutputString(consumed);
+    errorBudgetRemainingPct = toOutputString(remaining.lessThan(0) ? new Decimal(0) : remaining);
+  }
+
+  return {
+    sloTarget,
+    period,
+    totalMinutes: toOutputString(totalMinutes),
+    allowableDowntimeMinutes: toOutputString(allowableDowntimeMinutes),
+    allowableDowntimeFormatted: formatMinutes(allowableDowntimeMinutes),
+    ...(errorBudgetConsumedPct !== undefined ? { errorBudgetConsumedPct } : {}),
+    ...(errorBudgetRemainingPct !== undefined ? { errorBudgetRemainingPct } : {}),
+    formulasApplied: ["slo.errorBudget.allowableDowntime"],
+  };
+}
+
+// ─── Downtime cost ────────────────────────────────────────────────────────────
+
+export function computeDowntimeCost(input: DowntimeCostInput): DowntimeCostResult {
+  const warnings: string[] = [];
+  const outageHours = new Decimal(input.outageMinutes).div(60);
+  const revenueRate = new Decimal(input.revenueAtRiskPerHour);
+  const revenueCost = outageHours.mul(revenueRate);
+
+  let engineeringCost = new Decimal(0);
+  if (input.engineeringCostPerHour !== undefined && input.engineersOnCall !== undefined) {
+    engineeringCost = outageHours
+      .mul(new Decimal(input.engineeringCostPerHour))
+      .mul(new Decimal(input.engineersOnCall));
+  } else if (input.engineeringCostPerHour !== undefined || input.engineersOnCall !== undefined) {
+    warnings.push(
+      "Both engineeringCostPerHour and engineersOnCall are required to compute engineering cost — skipping.",
+    );
+  }
+
+  const totalCost = revenueCost.add(engineeringCost);
+
+  return {
+    outageMinutes: input.outageMinutes,
+    revenueCost: toOutputString(revenueCost),
+    engineeringCost: toOutputString(engineeringCost),
+    totalCost: toOutputString(totalCost),
+    currency: input.currency,
+    formulasApplied: ["slo.downtimeCost.revenue", "slo.downtimeCost.engineering"],
+    warnings,
+  };
+}
+
+// ─── Reliability ROI ──────────────────────────────────────────────────────────
+
+export function computeReliabilityRoi(input: ReliabilityRoiInput): ReliabilityRoiResult {
+  const warnings: string[] = [];
+  const totalMinutes = new Decimal(MINUTES_IN_PERIOD[input.period]);
+
+  const currentDowntimePct = new Decimal(100).minus(new Decimal(input.currentUptimePct));
+  const targetDowntimePct = new Decimal(100).minus(new Decimal(input.targetUptimePct));
+
+  if (targetDowntimePct.greaterThanOrEqualTo(currentDowntimePct)) {
+    warnings.push(
+      "targetUptimePct is not higher than currentUptimePct — no reliability improvement modelled.",
+    );
+  }
+
+  const currentDowntimeMinutes = totalMinutes.mul(currentDowntimePct).div(100);
+  const targetDowntimeMinutes = totalMinutes.mul(targetDowntimePct).div(100);
+  const rawSaved = currentDowntimeMinutes.minus(targetDowntimeMinutes);
+  const downtimeMinutesSaved = rawSaved.lessThan(0) ? new Decimal(0) : rawSaved;
+
+  const downtimeHoursSaved = downtimeMinutesSaved.div(60);
+  const revenueProtectedPerPeriod = downtimeHoursSaved.mul(new Decimal(input.revenueAtRiskPerHour));
+  const improvementCost = new Decimal(input.improvementCost);
+
+  const roiMultiple = improvementCost.isZero()
+    ? new Decimal(0)
+    : revenueProtectedPerPeriod.div(improvementCost);
+
+  const paybackPeriods = revenueProtectedPerPeriod.isZero()
+    ? new Decimal(0)
+    : improvementCost.div(revenueProtectedPerPeriod);
+
+  return {
+    downtimeMinutesSaved: toOutputString(downtimeMinutesSaved),
+    revenueProtectedPerPeriod: toOutputString(revenueProtectedPerPeriod),
+    roiMultiple: toOutputString(roiMultiple),
+    paybackPeriods: toOutputString(paybackPeriods),
+    currency: input.currency,
+    period: input.period,
+    formulasApplied: ["slo.reliability.roi", "slo.reliability.payback"],
+    warnings,
+  };
+}

--- a/packages/sla-slo-sli-economics/src/index.ts
+++ b/packages/sla-slo-sli-economics/src/index.ts
@@ -1,0 +1,10 @@
+export type {
+  SloTarget,
+  ErrorBudgetResult,
+  DowntimeCostInput,
+  DowntimeCostResult,
+  ReliabilityRoiInput,
+  ReliabilityRoiResult,
+} from "./types.js";
+export { STANDARD_SLO_TIERS } from "./types.js";
+export { computeErrorBudget, computeDowntimeCost, computeReliabilityRoi } from "./engine.js";

--- a/packages/sla-slo-sli-economics/src/types.ts
+++ b/packages/sla-slo-sli-economics/src/types.ts
@@ -1,0 +1,132 @@
+import type { Period } from "@ficecal/core-economics";
+
+// ─── SLO target ───────────────────────────────────────────────────────────────
+
+/**
+ * A Service Level Objective expressed as a percentage uptime target.
+ * Canonical SLO tiers map to allowable downtime per period.
+ */
+export interface SloTarget {
+  /** Human label, e.g. "99.9% uptime" */
+  label: string;
+  /** Uptime percentage as a decimal string, e.g. "99.9" */
+  uptimePct: string;
+}
+
+/** Commonly referenced SLO tiers. */
+export const STANDARD_SLO_TIERS: Record<string, SloTarget> = {
+  "99":    { label: "99% (two nines)",    uptimePct: "99" },
+  "99.5":  { label: "99.5%",              uptimePct: "99.5" },
+  "99.9":  { label: "99.9% (three nines)", uptimePct: "99.9" },
+  "99.95": { label: "99.95%",             uptimePct: "99.95" },
+  "99.99": { label: "99.99% (four nines)", uptimePct: "99.99" },
+  "99.999":{ label: "99.999% (five nines)", uptimePct: "99.999" },
+};
+
+// ─── Error budget ─────────────────────────────────────────────────────────────
+
+export interface ErrorBudgetResult {
+  /** SLO target used as input. */
+  sloTarget: SloTarget;
+
+  /** Billing period. */
+  period: Period;
+
+  /** Total minutes in the period. */
+  totalMinutes: string;
+
+  /** Allowable downtime minutes before SLO is breached. */
+  allowableDowntimeMinutes: string;
+
+  /** Allowable downtime as human-readable string, e.g. "43m 50s" */
+  allowableDowntimeFormatted: string;
+
+  /** Error budget consumed (0–100 as decimal string). */
+  errorBudgetConsumedPct?: string;
+
+  /** Remaining error budget (0–100 as decimal string). */
+  errorBudgetRemainingPct?: string;
+
+  formulasApplied: string[];
+}
+
+// ─── Downtime cost ────────────────────────────────────────────────────────────
+
+export interface DowntimeCostInput {
+  /** Duration of the outage in minutes. */
+  outageMinutes: number;
+
+  /**
+   * Revenue at risk per hour of downtime (decimal string).
+   * Represents lost transactions, SLA penalties, or engineer cost.
+   */
+  revenueAtRiskPerHour: string;
+
+  /** Optional: engineering cost per engineer per hour (decimal string). */
+  engineeringCostPerHour?: string;
+
+  /** Number of engineers involved in incident response. */
+  engineersOnCall?: number;
+
+  /** ISO 4217 currency. */
+  currency: string;
+}
+
+export interface DowntimeCostResult {
+  /** Outage duration in minutes (input). */
+  outageMinutes: number;
+
+  /** Revenue impact as decimal-safe string. */
+  revenueCost: string;
+
+  /** Engineering response cost as decimal-safe string (0 if not provided). */
+  engineeringCost: string;
+
+  /** Total cost (revenue + engineering) as decimal-safe string. */
+  totalCost: string;
+
+  currency: string;
+  formulasApplied: string[];
+  warnings: string[];
+}
+
+// ─── Reliability ROI ──────────────────────────────────────────────────────────
+
+export interface ReliabilityRoiInput {
+  /** Cost to improve reliability from currentUptimePct to targetUptimePct (decimal string). */
+  improvementCost: string;
+
+  /** Current uptime percentage as decimal string, e.g. "99.5" */
+  currentUptimePct: string;
+
+  /** Target uptime percentage as decimal string, e.g. "99.9" */
+  targetUptimePct: string;
+
+  /** Revenue at risk per hour (decimal string). */
+  revenueAtRiskPerHour: string;
+
+  /** Billing period to project over. */
+  period: Period;
+
+  /** ISO 4217 currency. */
+  currency: string;
+}
+
+export interface ReliabilityRoiResult {
+  /** Downtime minutes saved per period by achieving the target SLO. */
+  downtimeMinutesSaved: string;
+
+  /** Revenue protected per period (saved downtime × revenue rate). */
+  revenueProtectedPerPeriod: string;
+
+  /** Simple ROI: revenueProtected / improvementCost (as decimal string). */
+  roiMultiple: string;
+
+  /** Payback period in number of billing periods (decimal string). */
+  paybackPeriods: string;
+
+  currency: string;
+  period: Period;
+  formulasApplied: string[];
+  warnings: string[];
+}

--- a/packages/sla-slo-sli-economics/tests/engine.test.ts
+++ b/packages/sla-slo-sli-economics/tests/engine.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeErrorBudget,
+  computeDowntimeCost,
+  computeReliabilityRoi,
+  STANDARD_SLO_TIERS,
+} from "../src/index.js";
+
+describe("STANDARD_SLO_TIERS", () => {
+  it("defines the six canonical tiers", () => {
+    expect(Object.keys(STANDARD_SLO_TIERS)).toContain("99.9");
+    expect(Object.keys(STANDARD_SLO_TIERS)).toContain("99.99");
+    expect(Object.keys(STANDARD_SLO_TIERS)).toContain("99.999");
+  });
+});
+
+describe("computeErrorBudget", () => {
+  it("99.9% monthly → ~43.83 allowable downtime minutes", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.9"]!, "monthly");
+    const mins = parseFloat(r.allowableDowntimeMinutes);
+    expect(mins).toBeGreaterThan(43);
+    expect(mins).toBeLessThan(44);
+  });
+
+  it("99.99% monthly → ~4.38 allowable downtime minutes", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.99"]!, "monthly");
+    const mins = parseFloat(r.allowableDowntimeMinutes);
+    expect(mins).toBeGreaterThan(4);
+    expect(mins).toBeLessThan(5);
+  });
+
+  it("99% annual → ~3.65 days of allowable downtime", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99"]!, "annual");
+    const mins = parseFloat(r.allowableDowntimeMinutes);
+    // 1% of 525948.75 ≈ 5259 minutes ≈ 3.65 days
+    expect(mins).toBeGreaterThan(5000);
+    expect(mins).toBeLessThan(6000);
+  });
+
+  it("allowableDowntimeFormatted is a non-empty string", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.9"]!, "monthly");
+    expect(r.allowableDowntimeFormatted.length).toBeGreaterThan(0);
+  });
+
+  it("with actualUptimePct: error budget consumed and remaining sum to 100", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.9"]!, "monthly", {
+      actualUptimePct: "99.8",  // slightly worse than 99.9 target
+    });
+    expect(r.errorBudgetConsumedPct).toBeDefined();
+    expect(r.errorBudgetRemainingPct).toBeDefined();
+    const consumed = parseFloat(r.errorBudgetConsumedPct!);
+    const remaining = parseFloat(r.errorBudgetRemainingPct!);
+    expect(consumed + remaining).toBeCloseTo(100, 1);
+    expect(consumed).toBeGreaterThan(0);
+  });
+
+  it("actual uptime at exactly SLO target → 100% consumed (all budget used, none remaining)", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.9"]!, "monthly", {
+      actualUptimePct: "99.9",
+    });
+    expect(parseFloat(r.errorBudgetConsumedPct!)).toBeCloseTo(100, 1);
+    expect(parseFloat(r.errorBudgetRemainingPct!)).toBeCloseTo(0, 1);
+  });
+
+  it("actual uptime worse than target → 100% consumed (clamped)", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.9"]!, "monthly", {
+      actualUptimePct: "99.0",  // much worse
+    });
+    expect(parseFloat(r.errorBudgetConsumedPct!)).toBeCloseTo(100, 0);
+    expect(parseFloat(r.errorBudgetRemainingPct!)).toBeCloseTo(0, 0);
+  });
+
+  it("includes formulasApplied", () => {
+    const r = computeErrorBudget(STANDARD_SLO_TIERS["99.9"]!, "monthly");
+    expect(r.formulasApplied).toContain("slo.errorBudget.allowableDowntime");
+  });
+});
+
+describe("computeDowntimeCost", () => {
+  it("60 min outage at $10k/hr → $10k revenue cost", () => {
+    const r = computeDowntimeCost({
+      outageMinutes: 60,
+      revenueAtRiskPerHour: "10000",
+      currency: "USD",
+    });
+    expect(r.revenueCost).toBe("10000.0000000000");
+    expect(r.engineeringCost).toBe("0.0000000000");
+    expect(r.totalCost).toBe("10000.0000000000");
+  });
+
+  it("30 min outage at $10k/hr → $5k revenue cost", () => {
+    const r = computeDowntimeCost({
+      outageMinutes: 30,
+      revenueAtRiskPerHour: "10000",
+      currency: "USD",
+    });
+    expect(r.revenueCost).toBe("5000.0000000000");
+  });
+
+  it("includes engineering cost when both fields provided", () => {
+    // 2hr outage, $10k/hr revenue, 3 engineers at $150/hr
+    const r = computeDowntimeCost({
+      outageMinutes: 120,
+      revenueAtRiskPerHour: "10000",
+      engineeringCostPerHour: "150",
+      engineersOnCall: 3,
+      currency: "USD",
+    });
+    // revenue: 2 × 10000 = 20000; eng: 2 × 150 × 3 = 900; total: 20900
+    expect(r.revenueCost).toBe("20000.0000000000");
+    expect(r.engineeringCost).toBe("900.0000000000");
+    expect(r.totalCost).toBe("20900.0000000000");
+  });
+
+  it("warns when only one of engineering fields is provided", () => {
+    const r = computeDowntimeCost({
+      outageMinutes: 60,
+      revenueAtRiskPerHour: "5000",
+      engineeringCostPerHour: "100",
+      // engineersOnCall missing
+      currency: "USD",
+    });
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(r.engineeringCost).toBe("0.0000000000");
+  });
+
+  it("zero-minute outage produces zero cost", () => {
+    const r = computeDowntimeCost({
+      outageMinutes: 0,
+      revenueAtRiskPerHour: "10000",
+      currency: "USD",
+    });
+    expect(r.totalCost).toBe("0.0000000000");
+  });
+});
+
+describe("computeReliabilityRoi", () => {
+  it("improving from 99.5% to 99.9% monthly with $50k investment", () => {
+    const r = computeReliabilityRoi({
+      improvementCost: "50000",
+      currentUptimePct: "99.5",
+      targetUptimePct: "99.9",
+      revenueAtRiskPerHour: "10000",
+      period: "monthly",
+      currency: "USD",
+    });
+    // minutes saved: (0.5% - 0.1%) of monthly = 0.4% of 43829 ≈ 175 minutes ≈ 2.92 hours
+    // revenue protected: 2.92 × 10000 ≈ $29,200/month
+    const minutesSaved = parseFloat(r.downtimeMinutesSaved);
+    expect(minutesSaved).toBeGreaterThan(150);
+    expect(minutesSaved).toBeLessThan(200);
+    const revenue = parseFloat(r.revenueProtectedPerPeriod);
+    expect(revenue).toBeGreaterThan(20000);
+    expect(revenue).toBeLessThan(35000);
+  });
+
+  it("roiMultiple and paybackPeriods are reciprocals", () => {
+    const r = computeReliabilityRoi({
+      improvementCost: "50000",
+      currentUptimePct: "99.5",
+      targetUptimePct: "99.9",
+      revenueAtRiskPerHour: "10000",
+      period: "monthly",
+      currency: "USD",
+    });
+    const roi = parseFloat(r.roiMultiple);
+    const payback = parseFloat(r.paybackPeriods);
+    expect(roi * payback).toBeCloseTo(1.0, 3);
+  });
+
+  it("warns when target is not higher than current", () => {
+    const r = computeReliabilityRoi({
+      improvementCost: "10000",
+      currentUptimePct: "99.9",
+      targetUptimePct: "99.5",
+      revenueAtRiskPerHour: "5000",
+      period: "monthly",
+      currency: "USD",
+    });
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(r.downtimeMinutesSaved).toBe("0.0000000000");
+  });
+
+  it("includes formulasApplied", () => {
+    const r = computeReliabilityRoi({
+      improvementCost: "10000",
+      currentUptimePct: "99.5",
+      targetUptimePct: "99.9",
+      revenueAtRiskPerHour: "5000",
+      period: "monthly",
+      currency: "USD",
+    });
+    expect(r.formulasApplied).toContain("slo.reliability.roi");
+    expect(r.formulasApplied).toContain("slo.reliability.payback");
+  });
+});

--- a/packages/sla-slo-sli-economics/tsconfig.json
+++ b/packages/sla-slo-sli-economics/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,25 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.15)
 
+  packages/sla-slo-sli-economics:
+    dependencies:
+      '@ficecal/core-economics':
+        specifier: workspace:*
+        version: link:../core-economics
+      decimal.js:
+        specifier: ^10.4.3
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.15)
+
 packages:
 
   '@babel/code-frame@7.29.0':


### PR DESCRIPTION
## Summary
- New package `@ficecal/sla-slo-sli-economics` — Phase 2 reliability economics
- `computeErrorBudget`: allowable downtime per period, error budget consumed/remaining %
- `computeDowntimeCost`: revenue impact + engineering response cost (decimal-safe)
- `computeReliabilityRoi`: ROI multiple, payback periods, downtime minutes saved
- `STANDARD_SLO_TIERS`: canonical 99% → 99.999% targets
- 18 vitest tests, all passing

## Phase 2 progress
Closes reliability-economics module (one of nine Phase 2 deliverables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)