### PR TITLE
feat(economics-module): Phase 2 unified economics registry and plugin umbrella

### DIFF
--- a/packages/economics-module/package.json
+++ b/packages/economics-module/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ficecal/economics-module",
+  "version": "1.0.0",
+  "description": "FiceCal v2 — unified economics umbrella: registry, dispatcher, and extension interface for all economics engines",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run"
+  },
+  "dependencies": {
+    "@ficecal/core-economics": "workspace:*",
+    "@ficecal/ai-token-economics": "workspace:*",
+    "@ficecal/sla-slo-sli-economics": "workspace:*",
+    "@ficecal/multi-tech-normalization": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.1",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/economics-module/src/built-in-plugins.ts
+++ b/packages/economics-module/src/built-in-plugins.ts
@@ -1,0 +1,104 @@
+/**
+ * Built-in economics plugins — one per domain module.
+ *
+ * Each plugin wraps an engine from a sub-package into the EconomicsPlugin
+ * interface so it can be auto-registered in the default EconomicsRegistry
+ * instance (see createDefaultRegistry).
+ *
+ * Extension pattern for future modules (cloud-economics, licensing, etc.):
+ *   1. Create @ficecal/<domain>-economics package with its own engine
+ *   2. Add an EconomicsPlugin wrapper here (or in the package itself)
+ *   3. Register it in createDefaultRegistry()
+ */
+
+import { computeAiCost } from "@ficecal/ai-token-economics";
+import type { AiCostInput, AiCostResult } from "@ficecal/ai-token-economics";
+
+import {
+  computeErrorBudget,
+  computeDowntimeCost,
+  computeReliabilityRoi,
+} from "@ficecal/sla-slo-sli-economics";
+import type {
+  SloTarget,
+  DowntimeCostInput,
+  ReliabilityRoiInput,
+} from "@ficecal/sla-slo-sli-economics";
+
+import { normalizeTechCosts } from "@ficecal/multi-tech-normalization";
+import type {
+  TechCostInput,
+  TechNormalizationResult,
+} from "@ficecal/multi-tech-normalization";
+
+import type { Period } from "@ficecal/core-economics";
+import type { EconomicsPlugin } from "./types.js";
+
+// ─── ai.token ─────────────────────────────────────────────────────────────────
+
+export const aiTokenPlugin: EconomicsPlugin<AiCostInput, AiCostResult> = {
+  domain: "ai.token",
+  version: "1.0.0",
+  description: "AI inference cost calculation: token, image, request, and time-based pricing units",
+  compute: computeAiCost,
+};
+
+// ─── reliability.error-budget ─────────────────────────────────────────────────
+
+export interface ErrorBudgetPluginInput {
+  sloTarget: SloTarget;
+  period: Period;
+  options?: { actualUptimePct?: string };
+}
+
+export const reliabilityErrorBudgetPlugin: EconomicsPlugin<
+  ErrorBudgetPluginInput,
+  ReturnType<typeof computeErrorBudget>
+> = {
+  domain: "reliability.error-budget",
+  version: "1.0.0",
+  description: "SLO error budget: allowable downtime per period, budget consumed/remaining %",
+  compute: ({ sloTarget, period, options }) =>
+    computeErrorBudget(sloTarget, period, options),
+};
+
+// ─── reliability.downtime-cost ────────────────────────────────────────────────
+
+export const reliabilityDowntimeCostPlugin: EconomicsPlugin<
+  DowntimeCostInput,
+  ReturnType<typeof computeDowntimeCost>
+> = {
+  domain: "reliability.downtime-cost",
+  version: "1.0.0",
+  description: "Downtime cost: revenue impact plus engineering response cost during outages",
+  compute: computeDowntimeCost,
+};
+
+// ─── reliability.roi ─────────────────────────────────────────────────────────
+
+export const reliabilityRoiPlugin: EconomicsPlugin<
+  ReliabilityRoiInput,
+  ReturnType<typeof computeReliabilityRoi>
+> = {
+  domain: "reliability.roi",
+  version: "1.0.0",
+  description: "Reliability ROI: minutes saved, revenue protected, ROI multiple, payback periods",
+  compute: computeReliabilityRoi,
+};
+
+// ─── tech.normalization ───────────────────────────────────────────────────────
+
+export interface TechNormalizationPluginInput {
+  items: TechCostInput[];
+  currency: string;
+}
+
+export const techNormalizationPlugin: EconomicsPlugin<
+  TechNormalizationPluginInput,
+  TechNormalizationResult
+> = {
+  domain: "tech.normalization",
+  version: "1.0.0",
+  description: "Multi-technology cost normalization: per-unit basis, efficiency index, portfolio roll-up",
+  compute: ({ items, currency }) => normalizeTechCosts(items, currency),
+};

--- a/packages/economics-module/src/index.ts
+++ b/packages/economics-module/src/index.ts
@@ -1,0 +1,99 @@
+// ─── Core types ───────────────────────────────────────────────────────────────
+export type {
+  EconomicsPlugin,
+  EconomicsDomainManifest,
+} from "./types.js";
+export { EconomicsRegistryError } from "./types.js";
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+export { EconomicsRegistry } from "./registry.js";
+
+// ─── Built-in plugins ─────────────────────────────────────────────────────────
+export {
+  aiTokenPlugin,
+  reliabilityErrorBudgetPlugin,
+  reliabilityDowntimeCostPlugin,
+  reliabilityRoiPlugin,
+  techNormalizationPlugin,
+} from "./built-in-plugins.js";
+export type {
+  ErrorBudgetPluginInput,
+  TechNormalizationPluginInput,
+} from "./built-in-plugins.js";
+
+// ─── Default registry factory ─────────────────────────────────────────────────
+import { EconomicsRegistry } from "./registry.js";
+import {
+  aiTokenPlugin,
+  reliabilityErrorBudgetPlugin,
+  reliabilityDowntimeCostPlugin,
+  reliabilityRoiPlugin,
+  techNormalizationPlugin,
+} from "./built-in-plugins.js";
+
+/**
+ * Create a pre-populated EconomicsRegistry with all built-in plugins registered.
+ *
+ * Returns a new registry instance each call — callers own their instance.
+ * Additional plugins can be registered after creation without affecting other
+ * registries.
+ *
+ * Built-in domains:
+ *   - ai.token                  (@ficecal/ai-token-economics)
+ *   - reliability.error-budget  (@ficecal/sla-slo-sli-economics)
+ *   - reliability.downtime-cost (@ficecal/sla-slo-sli-economics)
+ *   - reliability.roi           (@ficecal/sla-slo-sli-economics)
+ *   - tech.normalization        (@ficecal/multi-tech-normalization)
+ */
+export function createDefaultRegistry(): EconomicsRegistry {
+  const registry = new EconomicsRegistry();
+  registry.register(aiTokenPlugin);
+  registry.register(reliabilityErrorBudgetPlugin);
+  registry.register(reliabilityDowntimeCostPlugin);
+  registry.register(reliabilityRoiPlugin);
+  registry.register(techNormalizationPlugin);
+  return registry;
+}
+
+// ─── Sub-module re-exports (for convenience; avoid double-import) ─────────────
+
+// core-economics
+export type { Period, Currency } from "@ficecal/core-economics";
+export { Decimal, toOutputString, normalizePeriod } from "@ficecal/core-economics";
+
+// ai-token-economics
+export type {
+  AiPricingUnit,
+  AiCostInput,
+  AiCostResult,
+  TokenCostInput,
+  ImageCostInput,
+  RequestCostInput,
+  TimeCostInput,
+} from "@ficecal/ai-token-economics";
+export { computeAiCost } from "@ficecal/ai-token-economics";
+
+// sla-slo-sli-economics
+export type {
+  SloTarget,
+  ErrorBudgetResult,
+  DowntimeCostInput,
+  DowntimeCostResult,
+  ReliabilityRoiInput,
+  ReliabilityRoiResult,
+} from "@ficecal/sla-slo-sli-economics";
+export {
+  STANDARD_SLO_TIERS,
+  computeErrorBudget,
+  computeDowntimeCost,
+  computeReliabilityRoi,
+} from "@ficecal/sla-slo-sli-economics";
+
+// multi-tech-normalization
+export type {
+  TechCategory,
+  TechCostInput,
+  NormalizedTechCost,
+  TechNormalizationResult,
+} from "@ficecal/multi-tech-normalization";
+export { normalizeTechCosts, CATEGORY_BASIS_UNIT } from "@ficecal/multi-tech-normalization";

--- a/packages/economics-module/src/registry.ts
+++ b/packages/economics-module/src/registry.ts
@@ -1,0 +1,111 @@
+import type {
+  EconomicsPlugin,
+  EconomicsDomainManifest,
+} from "./types.js";
+import { EconomicsRegistryError } from "./types.js";
+
+// ─── EconomicsRegistry ────────────────────────────────────────────────────────
+
+/**
+ * Central registry for all FiceCal economics engines.
+ *
+ * Design goals:
+ * - Single import surface: consumers import one package and get every engine
+ * - Plugin extension: future modules (cloud-economics, licensing, FinOps)
+ *   self-register without changing core consumers
+ * - Type-safe dispatch: lookup<TInput, TResult>() narrows plugin types at
+ *   call site; registry internals use `unknown` to avoid a mega-union type
+ */
+export class EconomicsRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly plugins = new Map<string, EconomicsPlugin<any, any>>();
+
+  // ─── Registration ──────────────────────────────────────────────────────────
+
+  /**
+   * Register an economics plugin. Throws if the domain is already taken.
+   * To replace, call unregister() first.
+   */
+  register<TInput, TResult>(plugin: EconomicsPlugin<TInput, TResult>): void {
+    if (this.plugins.has(plugin.domain)) {
+      throw new EconomicsRegistryError(
+        "DOMAIN_ALREADY_REGISTERED",
+        `Domain "${plugin.domain}" is already registered. Call unregister() first to replace it.`,
+      );
+    }
+    this.plugins.set(plugin.domain, plugin);
+  }
+
+  /**
+   * Remove a plugin by domain. Safe to call even if not registered.
+   */
+  unregister(domain: string): boolean {
+    return this.plugins.delete(domain);
+  }
+
+  // ─── Lookup ────────────────────────────────────────────────────────────────
+
+  /**
+   * Look up a plugin by domain, narrowing to the expected TInput/TResult types.
+   * Returns undefined if the domain is not registered.
+   */
+  lookup<TInput = unknown, TResult = unknown>(
+    domain: string,
+  ): EconomicsPlugin<TInput, TResult> | undefined {
+    return this.plugins.get(domain) as EconomicsPlugin<TInput, TResult> | undefined;
+  }
+
+  /**
+   * Look up a plugin or throw EconomicsRegistryError("DOMAIN_NOT_FOUND").
+   */
+  require<TInput = unknown, TResult = unknown>(
+    domain: string,
+  ): EconomicsPlugin<TInput, TResult> {
+    const plugin = this.lookup<TInput, TResult>(domain);
+    if (!plugin) {
+      throw new EconomicsRegistryError(
+        "DOMAIN_NOT_FOUND",
+        `No economics plugin registered for domain "${domain}". Registered: [${this.listDomains().join(", ")}]`,
+      );
+    }
+    return plugin;
+  }
+
+  // ─── Dispatch ──────────────────────────────────────────────────────────────
+
+  /**
+   * Convenience dispatcher — looks up the plugin by domain and invokes compute().
+   * Throws DOMAIN_NOT_FOUND if unregistered, or COMPUTE_ERROR if compute throws.
+   */
+  compute<TInput, TResult>(domain: string, input: TInput): TResult {
+    const plugin = this.require<TInput, TResult>(domain);
+    try {
+      return plugin.compute(input);
+    } catch (err) {
+      throw new EconomicsRegistryError(
+        "COMPUTE_ERROR",
+        `Plugin "${domain}" threw during compute: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // ─── Introspection ─────────────────────────────────────────────────────────
+
+  /** List all registered domain keys. */
+  listDomains(): string[] {
+    return [...this.plugins.keys()].sort();
+  }
+
+  /** Return a structured manifest of all registered plugins. */
+  manifest(): EconomicsDomainManifest[] {
+    return this.listDomains().map((domain) => {
+      const p = this.plugins.get(domain)!;
+      return { domain: p.domain, version: p.version, description: p.description };
+    });
+  }
+
+  /** Number of registered plugins. */
+  get size(): number {
+    return this.plugins.size;
+  }
+}

--- a/packages/economics-module/src/types.ts
+++ b/packages/economics-module/src/types.ts
@@ -1,0 +1,46 @@
+// ─── Economics plugin interface ────────────────────────────────────────────────
+
+/**
+ * Contract that every economics engine must satisfy to self-register with the
+ * EconomicsRegistry. The generic parameters are intentionally open so the
+ * registry can hold mixed-domain plugins without requiring a discriminated union
+ * at registration time; call sites narrow types via lookup<TInput, TResult>().
+ */
+export interface EconomicsPlugin<TInput = unknown, TResult = unknown> {
+  /** Stable dot-namespaced domain key. e.g. "ai.token", "reliability.slo", "tech.normalization" */
+  readonly domain: string;
+
+  /** Semver string for this plugin's computation contract. */
+  readonly version: string;
+
+  /** Human-readable description shown in capabilities manifests. */
+  readonly description: string;
+
+  /** Executes the economics computation and returns a typed result. */
+  compute(input: TInput): TResult;
+}
+
+// ─── Registry error ────────────────────────────────────────────────────────────
+
+export type EconomicsRegistryErrorCode =
+  | "DOMAIN_NOT_FOUND"
+  | "DOMAIN_ALREADY_REGISTERED"
+  | "COMPUTE_ERROR";
+
+export class EconomicsRegistryError extends Error {
+  constructor(
+    public readonly code: EconomicsRegistryErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EconomicsRegistryError";
+  }
+}
+
+// ─── Domain manifest entry ─────────────────────────────────────────────────────
+
+export interface EconomicsDomainManifest {
+  domain: string;
+  version: string;
+  description: string;
+}

--- a/packages/economics-module/tests/registry.test.ts
+++ b/packages/economics-module/tests/registry.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  EconomicsRegistry,
+  EconomicsRegistryError,
+  createDefaultRegistry,
+  aiTokenPlugin,
+  reliabilityErrorBudgetPlugin,
+  reliabilityDowntimeCostPlugin,
+  reliabilityRoiPlugin,
+  techNormalizationPlugin,
+  STANDARD_SLO_TIERS,
+} from "../src/index.js";
+import type { EconomicsPlugin } from "../src/index.js";
+
+// ─── EconomicsRegistry unit ───────────────────────────────────────────────────
+
+describe("EconomicsRegistry", () => {
+  let registry: EconomicsRegistry;
+
+  beforeEach(() => {
+    registry = new EconomicsRegistry();
+  });
+
+  it("starts empty", () => {
+    expect(registry.size).toBe(0);
+    expect(registry.listDomains()).toEqual([]);
+  });
+
+  it("register and lookup a plugin", () => {
+    const plugin: EconomicsPlugin<number, number> = {
+      domain: "test.double",
+      version: "1.0.0",
+      description: "doubles its input",
+      compute: (n) => n * 2,
+    };
+    registry.register(plugin);
+    expect(registry.size).toBe(1);
+    const found = registry.lookup<number, number>("test.double");
+    expect(found).toBeDefined();
+    expect(found!.compute(21)).toBe(42);
+  });
+
+  it("throws DOMAIN_ALREADY_REGISTERED on duplicate register", () => {
+    const plugin: EconomicsPlugin<number, number> = {
+      domain: "test.duplicate",
+      version: "1.0.0",
+      description: "test",
+      compute: (n) => n,
+    };
+    registry.register(plugin);
+    expect(() => registry.register(plugin)).toThrow(EconomicsRegistryError);
+    try {
+      registry.register(plugin);
+    } catch (err) {
+      expect((err as EconomicsRegistryError).code).toBe("DOMAIN_ALREADY_REGISTERED");
+    }
+  });
+
+  it("unregister removes a plugin", () => {
+    const plugin: EconomicsPlugin<number, number> = {
+      domain: "test.remove",
+      version: "1.0.0",
+      description: "test",
+      compute: (n) => n,
+    };
+    registry.register(plugin);
+    expect(registry.size).toBe(1);
+    const removed = registry.unregister("test.remove");
+    expect(removed).toBe(true);
+    expect(registry.size).toBe(0);
+  });
+
+  it("unregister on missing domain returns false", () => {
+    expect(registry.unregister("does.not.exist")).toBe(false);
+  });
+
+  it("require throws DOMAIN_NOT_FOUND for unregistered domain", () => {
+    expect(() => registry.require("missing.domain")).toThrow(EconomicsRegistryError);
+    try {
+      registry.require("missing.domain");
+    } catch (err) {
+      expect((err as EconomicsRegistryError).code).toBe("DOMAIN_NOT_FOUND");
+    }
+  });
+
+  it("compute dispatches correctly and returns result", () => {
+    const plugin: EconomicsPlugin<number, string> = {
+      domain: "test.stringify",
+      version: "1.0.0",
+      description: "test",
+      compute: (n) => `value:${n}`,
+    };
+    registry.register(plugin);
+    const result = registry.compute<number, string>("test.stringify", 99);
+    expect(result).toBe("value:99");
+  });
+
+  it("compute wraps thrown errors as COMPUTE_ERROR", () => {
+    const plugin: EconomicsPlugin<number, number> = {
+      domain: "test.throws",
+      version: "1.0.0",
+      description: "test",
+      compute: () => { throw new Error("boom"); },
+    };
+    registry.register(plugin);
+    expect(() => registry.compute("test.throws", 0)).toThrow(EconomicsRegistryError);
+    try {
+      registry.compute("test.throws", 0);
+    } catch (err) {
+      expect((err as EconomicsRegistryError).code).toBe("COMPUTE_ERROR");
+    }
+  });
+
+  it("listDomains returns sorted domain keys", () => {
+    const make = (domain: string): EconomicsPlugin<void, void> => ({
+      domain,
+      version: "1.0.0",
+      description: "test",
+      compute: () => undefined,
+    });
+    registry.register(make("z.last"));
+    registry.register(make("a.first"));
+    registry.register(make("m.middle"));
+    expect(registry.listDomains()).toEqual(["a.first", "m.middle", "z.last"]);
+  });
+
+  it("manifest returns all domain metadata", () => {
+    const plugin: EconomicsPlugin<void, void> = {
+      domain: "test.manifest",
+      version: "2.1.0",
+      description: "manifest test plugin",
+      compute: () => undefined,
+    };
+    registry.register(plugin);
+    const mf = registry.manifest();
+    expect(mf).toHaveLength(1);
+    expect(mf[0]).toEqual({
+      domain: "test.manifest",
+      version: "2.1.0",
+      description: "manifest test plugin",
+    });
+  });
+
+  it("allows re-register after unregister", () => {
+    const plugin: EconomicsPlugin<number, number> = {
+      domain: "test.replace",
+      version: "1.0.0",
+      description: "v1",
+      compute: (n) => n,
+    };
+    registry.register(plugin);
+    registry.unregister("test.replace");
+    const v2: EconomicsPlugin<number, number> = { ...plugin, version: "2.0.0", compute: (n) => n * 2 };
+    registry.register(v2);
+    expect(registry.require<number, number>("test.replace").version).toBe("2.0.0");
+  });
+});
+
+// ─── createDefaultRegistry ────────────────────────────────────────────────────
+
+describe("createDefaultRegistry", () => {
+  it("registers all 5 built-in domains", () => {
+    const r = createDefaultRegistry();
+    expect(r.size).toBe(5);
+    expect(r.listDomains()).toContain("ai.token");
+    expect(r.listDomains()).toContain("reliability.error-budget");
+    expect(r.listDomains()).toContain("reliability.downtime-cost");
+    expect(r.listDomains()).toContain("reliability.roi");
+    expect(r.listDomains()).toContain("tech.normalization");
+  });
+
+  it("each call returns an independent registry instance", () => {
+    const r1 = createDefaultRegistry();
+    const r2 = createDefaultRegistry();
+    r1.unregister("ai.token");
+    expect(r1.size).toBe(4);
+    expect(r2.size).toBe(5);
+  });
+
+  it("can extend with a custom plugin after creation", () => {
+    const r = createDefaultRegistry();
+    const plugin: EconomicsPlugin<number, number> = {
+      domain: "cloud.egress",
+      version: "1.0.0",
+      description: "Cloud egress cost",
+      compute: (gb) => gb * 0.09,
+    };
+    r.register(plugin);
+    expect(r.size).toBe(6);
+    expect(r.compute<number, number>("cloud.egress", 100)).toBeCloseTo(9.0, 5);
+  });
+});
+
+// ─── Built-in plugin integration ─────────────────────────────────────────────
+
+describe("ai.token plugin", () => {
+  it("dispatches token cost via registry", () => {
+    const r = createDefaultRegistry();
+    const result = r.compute("ai.token", {
+      pricingUnit: "per_1m_tokens",
+      inputTokens: 1000,
+      outputTokens: 500,
+      inputPricePerUnit: "3.00",
+      outputPricePerUnit: "15.00",
+      currency: "USD",
+      period: "monthly",
+    });
+    expect(result).toBeDefined();
+    expect((result as { totalCost: string }).totalCost).toBeDefined();
+  });
+
+  it("direct plugin compute matches registry dispatch", () => {
+    const r = createDefaultRegistry();
+    const input = {
+      pricingUnit: "per_1m_tokens" as const,
+      inputTokens: 500,
+      outputTokens: 250,
+      inputPricePerUnit: "1.00",
+      outputPricePerUnit: "3.00",
+      currency: "USD",
+      period: "monthly" as const,
+    };
+    const direct = aiTokenPlugin.compute(input);
+    const dispatched = r.compute("ai.token", input) as typeof direct;
+    expect(direct.totalCost).toBe(dispatched.totalCost);
+  });
+});
+
+describe("reliability.error-budget plugin", () => {
+  it("dispatches error budget computation via registry", () => {
+    const r = createDefaultRegistry();
+    const result = r.compute("reliability.error-budget", {
+      sloTarget: STANDARD_SLO_TIERS["99.9"]!,
+      period: "monthly",
+    });
+    const eb = result as ReturnType<typeof reliabilityErrorBudgetPlugin.compute>;
+    const mins = parseFloat(eb.allowableDowntimeMinutes);
+    expect(mins).toBeGreaterThan(43);
+    expect(mins).toBeLessThan(44);
+  });
+
+  it("direct plugin compute matches registry dispatch", () => {
+    const r = createDefaultRegistry();
+    const input = {
+      sloTarget: STANDARD_SLO_TIERS["99.99"]!,
+      period: "monthly" as const,
+    };
+    const direct = reliabilityErrorBudgetPlugin.compute(input);
+    const dispatched = r.compute("reliability.error-budget", input) as typeof direct;
+    expect(direct.allowableDowntimeMinutes).toBe(dispatched.allowableDowntimeMinutes);
+  });
+});
+
+describe("reliability.downtime-cost plugin", () => {
+  it("dispatches downtime cost via registry", () => {
+    const r = createDefaultRegistry();
+    const result = r.compute("reliability.downtime-cost", {
+      outageMinutes: 60,
+      revenueAtRiskPerHour: "10000",
+      currency: "USD",
+    });
+    const dc = result as ReturnType<typeof reliabilityDowntimeCostPlugin.compute>;
+    expect(dc.totalCost).toBe("10000.0000000000");
+  });
+});
+
+describe("reliability.roi plugin", () => {
+  it("dispatches reliability ROI via registry", () => {
+    const r = createDefaultRegistry();
+    const result = r.compute("reliability.roi", {
+      improvementCost: "50000",
+      currentUptimePct: "99.5",
+      targetUptimePct: "99.9",
+      revenueAtRiskPerHour: "10000",
+      period: "monthly",
+      currency: "USD",
+    });
+    const roi = result as ReturnType<typeof reliabilityRoiPlugin.compute>;
+    expect(parseFloat(roi.downtimeMinutesSaved)).toBeGreaterThan(0);
+    expect(roi.formulasApplied).toContain("slo.reliability.roi");
+  });
+});
+
+describe("tech.normalization plugin", () => {
+  it("dispatches tech normalization via registry", () => {
+    const r = createDefaultRegistry();
+    const result = r.compute("tech.normalization", {
+      currency: "USD",
+      items: [
+        {
+          id: "gpu-1",
+          label: "GPU Instance",
+          category: "ai-inference",
+          rawCost: "100",
+          currency: "USD",
+          quantity: 100,
+          nativeUnit: "1M tokens",
+        },
+      ],
+    });
+    const tn = result as ReturnType<typeof techNormalizationPlugin.compute>;
+    expect(tn.items).toHaveLength(1);
+    expect(tn.dominantCategory).toBe("ai-inference");
+  });
+
+  it("direct plugin compute matches registry dispatch", () => {
+    const r = createDefaultRegistry();
+    const input = {
+      currency: "USD",
+      items: [
+        {
+          id: "s3-1",
+          label: "S3 Storage",
+          category: "cloud-storage" as const,
+          rawCost: "50",
+          currency: "USD",
+          quantity: 2000,
+          nativeUnit: "GB",
+        },
+      ],
+    };
+    const direct = techNormalizationPlugin.compute(input);
+    const dispatched = r.compute("tech.normalization", input) as typeof direct;
+    expect(direct.portfolioTotal).toBe(dispatched.portfolioTotal);
+  });
+});
+
+// ─── manifest ─────────────────────────────────────────────────────────────────
+
+describe("manifest()", () => {
+  it("manifest contains all built-in plugin metadata", () => {
+    const r = createDefaultRegistry();
+    const mf = r.manifest();
+    expect(mf).toHaveLength(5);
+    const domains = mf.map((m) => m.domain);
+    expect(domains).toContain("ai.token");
+    expect(domains).toContain("reliability.error-budget");
+    expect(domains).toContain("reliability.downtime-cost");
+    expect(domains).toContain("reliability.roi");
+    expect(domains).toContain("tech.normalization");
+    // each entry has version + description
+    mf.forEach((entry) => {
+      expect(entry.version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(entry.description.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/economics-module/tsconfig.json
+++ b/packages/economics-module/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,28 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.15)
 
+  packages/economics-module:
+    dependencies:
+      '@ficecal/ai-token-economics':
+        specifier: workspace:*
+        version: link:../ai-token-economics
+      '@ficecal/core-economics':
+        specifier: workspace:*
+        version: link:../core-economics
+      '@ficecal/multi-tech-normalization':
+        specifier: workspace:*
+        version: link:../multi-tech-normalization
+      '@ficecal/sla-slo-sli-economics':
+        specifier: workspace:*
+        version: link:../sla-slo-sli-economics
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.19.15)
+
   packages/feature-registry:
     devDependencies:
       '@types/node':
@@ -583,6 +605,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -609,6 +637,9 @@ packages:
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/mocker@2.1.9':
     resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
@@ -620,20 +651,46 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -708,6 +765,15 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -719,6 +785,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -757,12 +826,19 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -806,11 +882,18 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
@@ -820,8 +903,16 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
@@ -841,6 +932,11 @@ packages:
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@5.4.21:
@@ -887,6 +983,34 @@ packages:
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -1210,6 +1334,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.15':
@@ -1246,9 +1377,25 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.15))':
     dependencies:
       '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.15)
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.15))':
+    dependencies:
+      '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -1258,10 +1405,20 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
       pathe: 1.1.2
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -1269,15 +1426,31 @@ snapshots:
       magic-string: 0.30.21
       pathe: 1.1.2
 
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
 
   '@vitest/utils@2.1.9':
     dependencies:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   assertion-error@2.0.1: {}
 
@@ -1355,12 +1528,18 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
   fsevents@2.3.3:
     optional: true
 
   gensync@1.0.0-beta.2: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   jsesc@3.1.0: {}
 
@@ -1388,9 +1567,13 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
   pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
 
   postcss@8.5.8:
     dependencies:
@@ -1455,15 +1638,28 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
 
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyspy@3.0.2: {}
+
+  tinyspy@4.0.4: {}
 
   typescript@5.9.3: {}
 
@@ -1481,6 +1677,24 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@3.2.4(@types/node@22.19.15):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
       vite: 5.4.21(@types/node@22.19.15)
     transitivePeerDependencies:
       - '@types/node'
@@ -1523,6 +1737,44 @@ snapshots:
       tinyrainbow: 1.2.0
       vite: 5.4.21(@types/node@22.19.15)
       vite-node: 2.1.9(@types/node@22.19.15)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.2.4(@types/node@22.19.15):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.15))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@22.19.15)
+      vite-node: 3.2.4(@types/node@22.19.15)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15


### PR DESCRIPTION
## Summary
- New package `@ficecal/economics-module` — answers the economics umbrella architecture question
- `EconomicsPlugin<TInput, TResult>` interface: contract every economics engine must satisfy to self-register
- `EconomicsRegistry`: domain-keyed plugin store with register/unregister, lookup/require, compute dispatcher, manifest()
- `createDefaultRegistry()`: pre-wires all 5 built-in domains from Phase 2 sub-packages
- Re-exports all sub-module APIs as a single convenience import surface
- Extension pattern: future modules (cloud-economics, licensing, FinOps) call `registry.register(plugin)` — no core changes needed
- 23 vitest tests, all passing

## Built-in domains
| Domain | Source package |
|---|---|
| `ai.token` | `@ficecal/ai-token-economics` |
| `reliability.error-budget` | `@ficecal/sla-slo-sli-economics` |
| `reliability.downtime-cost` | `@ficecal/sla-slo-sli-economics` |
| `reliability.roi` | `@ficecal/sla-slo-sli-economics` |
| `tech.normalization` | `@ficecal/multi-tech-normalization` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `@ficecal/economics-module` package with a plugin-based registry system for managing economics computations.
  * Added five pre-built plugins for AI token costs, reliability metrics (error budgets, downtime costs, ROI), and technology cost normalization.
  * Provided `createDefaultRegistry()` function for quick setup with all built-in plugins pre-configured.

* **Tests**
  * Added comprehensive test coverage for registry operations and built-in plugin integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->