### PR TITLE
feat(budgeting-forecasting): Phase 2 budget variance, trend extrapolation, spend projection

### DIFF
--- a/packages/budgeting-forecasting/package.json
+++ b/packages/budgeting-forecasting/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ficecal/budgeting-forecasting",
+  "version": "1.0.0",
+  "description": "FiceCal v2 — budget projection, trend extrapolation, variance analysis, and spend forecasting",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run"
+  },
+  "dependencies": {
+    "@ficecal/core-economics": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.1",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/budgeting-forecasting/src/engine.ts
+++ b/packages/budgeting-forecasting/src/engine.ts
@@ -1,0 +1,263 @@
+import { Decimal, toOutputString } from "@ficecal/core-economics";
+import type {
+  BudgetLineItem,
+  BudgetVarianceResult,
+  TrendExtrapolationInput,
+  TrendExtrapolationResult,
+  BudgetProjectionInput,
+  BudgetProjectionResult,
+} from "./types.js";
+
+// ─── Budget variance ──────────────────────────────────────────────────────────
+
+/**
+ * Compute variance between budgeted and actual spend for each line item,
+ * plus portfolio totals.
+ *
+ * Formula: variance = actual − budgeted
+ * variancePct = (variance / budgeted) × 100  [0 when budgeted = 0]
+ */
+export function computeBudgetVariance(
+  items: BudgetLineItem[],
+  currency: string,
+): BudgetVarianceResult {
+  const warnings: string[] = [];
+
+  if (items.length === 0) {
+    warnings.push("No line items provided — result is empty.");
+  }
+
+  let totalBudgeted = new Decimal(0);
+  let totalActual = new Decimal(0);
+
+  const resultItems = items.map((item) => {
+    const budgeted = new Decimal(item.budgetedAmount);
+    const actual = new Decimal(item.actualAmount);
+    const variance = actual.minus(budgeted);
+    const variancePct = budgeted.isZero()
+      ? new Decimal(0)
+      : variance.div(budgeted).mul(100);
+
+    totalBudgeted = totalBudgeted.add(budgeted);
+    totalActual = totalActual.add(actual);
+
+    return {
+      id: item.id,
+      label: item.label,
+      budgetedAmount: toOutputString(budgeted),
+      actualAmount: toOutputString(actual),
+      varianceAmount: toOutputString(variance),
+      variancePct: toOutputString(variancePct),
+      isOverBudget: actual.greaterThan(budgeted),
+      currency: item.currency,
+    };
+  });
+
+  const totalVariance = totalActual.minus(totalBudgeted);
+  const totalVariancePct = totalBudgeted.isZero()
+    ? new Decimal(0)
+    : totalVariance.div(totalBudgeted).mul(100);
+
+  return {
+    items: resultItems,
+    totalBudgeted: toOutputString(totalBudgeted),
+    totalActual: toOutputString(totalActual),
+    totalVariance: toOutputString(totalVariance),
+    totalVariancePct: toOutputString(totalVariancePct),
+    isOverBudget: totalActual.greaterThan(totalBudgeted),
+    currency,
+    formulasApplied: ["budget.variance.item", "budget.variance.portfolio"],
+    warnings,
+  };
+}
+
+// ─── Trend extrapolation ──────────────────────────────────────────────────────
+
+/**
+ * Extrapolate future spend from historical observations using either:
+ * - linear: OLS regression on period index → y = slope × x + intercept
+ * - moving-average: simple mean of the last N observations
+ *
+ * Forecasted values are clamped to ≥ 0 (negative spend is not physical).
+ */
+export function extrapolateTrend(
+  input: TrendExtrapolationInput,
+): TrendExtrapolationResult {
+  const warnings: string[] = [];
+  const method = input.method ?? "linear";
+  const points = input.dataPoints;
+
+  if (points.length === 0) {
+    warnings.push("No data points provided — all forecasts default to 0.");
+    const zeroes = Array.from({ length: input.forecastPeriods }, (_, i) => ({
+      periodIndex: i + 1,
+      forecastedAmount: "0.0000000000",
+    }));
+    return {
+      method,
+      slopePerPeriod: "0.0000000000",
+      intercept: "0.0000000000",
+      movingAverage: "0.0000000000",
+      rSquared: "0.0000000000",
+      forecasts: zeroes,
+      currency: input.currency,
+      formulasApplied: ["forecast.trend.empty"],
+      warnings,
+    };
+  }
+
+  if (input.forecastPeriods < 1) {
+    warnings.push("forecastPeriods must be ≥ 1; defaulting to 1.");
+  }
+  const nForecast = Math.max(1, input.forecastPeriods);
+
+  const amounts = points.map((p) => new Decimal(p.amount));
+  const n = amounts.length;
+
+  if (method === "moving-average") {
+    const window = input.movingAverageWindow !== undefined
+      ? Math.min(Math.max(1, input.movingAverageWindow), n)
+      : n;
+
+    if (input.movingAverageWindow !== undefined && input.movingAverageWindow > n) {
+      warnings.push(
+        `movingAverageWindow (${input.movingAverageWindow}) exceeds available data points (${n}) — using all points.`,
+      );
+    }
+
+    const windowAmounts = amounts.slice(n - window);
+    const sum = windowAmounts.reduce((acc, v) => acc.add(v), new Decimal(0));
+    const avg = sum.div(window);
+
+    const forecasts = Array.from({ length: nForecast }, (_, i) => ({
+      periodIndex: i + 1,
+      forecastedAmount: toOutputString(avg.lessThan(0) ? new Decimal(0) : avg),
+    }));
+
+    return {
+      method,
+      slopePerPeriod: "0.0000000000",
+      intercept: "0.0000000000",
+      movingAverage: toOutputString(avg),
+      rSquared: "0.0000000000",
+      forecasts,
+      currency: input.currency,
+      formulasApplied: ["forecast.trend.movingAverage"],
+      warnings,
+    };
+  }
+
+  // ─── Linear OLS ─────────────────────────────────────────────────────────────
+  // x values: 1, 2, ..., n  (1-indexed for interpretability)
+  const xValues = Array.from({ length: n }, (_, i) => new Decimal(i + 1));
+
+  const sumX = xValues.reduce((acc, x) => acc.add(x), new Decimal(0));
+  const sumY = amounts.reduce((acc, y) => acc.add(y), new Decimal(0));
+  const sumXX = xValues.reduce((acc, x) => acc.add(x.mul(x)), new Decimal(0));
+  const sumXY = xValues.reduce(
+    (acc, x, i) => acc.add(x.mul(amounts[i]!)),
+    new Decimal(0),
+  );
+
+  const nD = new Decimal(n);
+  const denom = nD.mul(sumXX).minus(sumX.mul(sumX));
+
+  let slope: Decimal;
+  let intercept: Decimal;
+  let rSquared: Decimal;
+
+  if (denom.isZero()) {
+    // Single point or all same x — slope undefined, use mean
+    slope = new Decimal(0);
+    intercept = sumY.div(nD);
+    rSquared = new Decimal(0);
+    warnings.push("Degenerate data (single point or identical x values) — slope is 0, using mean as intercept.");
+  } else {
+    slope = nD.mul(sumXY).minus(sumX.mul(sumY)).div(denom);
+    intercept = sumY.minus(slope.mul(sumX)).div(nD);
+
+    // R² = 1 - SS_res / SS_tot
+    const yMean = sumY.div(nD);
+    const ssTot = amounts.reduce(
+      (acc, y) => acc.add(y.minus(yMean).pow(2)),
+      new Decimal(0),
+    );
+    const ssRes = amounts.reduce(
+      (acc, y, i) => acc.add(y.minus(slope.mul(xValues[i]!).add(intercept)).pow(2)),
+      new Decimal(0),
+    );
+    rSquared = ssTot.isZero()
+      ? new Decimal(1)
+      : new Decimal(1).minus(ssRes.div(ssTot));
+    // Clamp to [0, 1] — numerical issues can produce tiny negatives
+    rSquared = rSquared.lessThan(0) ? new Decimal(0) : rSquared.greaterThan(1) ? new Decimal(1) : rSquared;
+  }
+
+  const forecasts = Array.from({ length: nForecast }, (_, i) => {
+    const futureX = new Decimal(n + i + 1);
+    const raw = slope.mul(futureX).add(intercept);
+    return {
+      periodIndex: i + 1,
+      forecastedAmount: toOutputString(raw.lessThan(0) ? new Decimal(0) : raw),
+    };
+  });
+
+  return {
+    method: "linear",
+    slopePerPeriod: toOutputString(slope),
+    intercept: toOutputString(intercept),
+    movingAverage: "0.0000000000",
+    rSquared: toOutputString(rSquared),
+    forecasts,
+    currency: input.currency,
+    formulasApplied: ["forecast.trend.linear", "forecast.trend.rSquared"],
+    warnings,
+  };
+}
+
+// ─── Budget projection ────────────────────────────────────────────────────────
+
+/**
+ * Project future spend using compound growth.
+ *
+ * Formula: projected[i] = baseline × (1 + growthRate)^i
+ * where i = 1, 2, ..., periods
+ */
+export function projectBudget(
+  input: BudgetProjectionInput,
+): BudgetProjectionResult {
+  const warnings: string[] = [];
+  const baseline = new Decimal(input.baselineAmount);
+  const growthRate = new Decimal(input.growthRatePct).div(100);
+
+  if (baseline.lessThan(0)) {
+    warnings.push("baselineAmount is negative — projection may produce unexpected results.");
+  }
+  if (input.periods < 1) {
+    warnings.push("periods must be ≥ 1; defaulting to 1.");
+  }
+  const nPeriods = Math.max(1, input.periods);
+
+  let cumulative = new Decimal(0);
+  const periods = Array.from({ length: nPeriods }, (_, i) => {
+    const periodIndex = i + 1;
+    const projected = baseline.mul(new Decimal(1).add(growthRate).pow(periodIndex));
+    cumulative = cumulative.add(projected);
+    return {
+      periodIndex,
+      projectedAmount: toOutputString(projected),
+      cumulativeAmount: toOutputString(cumulative),
+    };
+  });
+
+  return {
+    baselineAmount: toOutputString(baseline),
+    growthRatePct: toOutputString(new Decimal(input.growthRatePct)),
+    periods,
+    totalProjected: toOutputString(cumulative),
+    currency: input.currency,
+    period: input.period,
+    formulasApplied: ["budget.projection.compoundGrowth"],
+    warnings,
+  };
+}

--- a/packages/budgeting-forecasting/src/index.ts
+++ b/packages/budgeting-forecasting/src/index.ts
@@ -1,0 +1,19 @@
+export type {
+  BudgetLineItem,
+  BudgetVarianceItem,
+  BudgetVarianceResult,
+  SpendDataPoint,
+  TrendMethod,
+  TrendExtrapolationInput,
+  ForecastDataPoint,
+  TrendExtrapolationResult,
+  BudgetProjectionInput,
+  ProjectedPeriod,
+  BudgetProjectionResult,
+} from "./types.js";
+
+export {
+  computeBudgetVariance,
+  extrapolateTrend,
+  projectBudget,
+} from "./engine.js";

--- a/packages/budgeting-forecasting/src/types.ts
+++ b/packages/budgeting-forecasting/src/types.ts
@@ -1,0 +1,146 @@
+import type { Period } from "@ficecal/core-economics";
+
+// ─── Budget line item ──────────────────────────────────────────────────────────
+
+/**
+ * A single budget line item representing a spending category or cost centre.
+ */
+export interface BudgetLineItem {
+  /** Stable unique identifier. */
+  id: string;
+
+  /** Human label. */
+  label: string;
+
+  /** Budgeted spend for this item in the current period (decimal string). */
+  budgetedAmount: string;
+
+  /** Actual spend recorded so far in the current period (decimal string). */
+  actualAmount: string;
+
+  /** ISO 4217 currency code. */
+  currency: string;
+}
+
+// ─── Budget variance result ────────────────────────────────────────────────────
+
+export interface BudgetVarianceItem {
+  id: string;
+  label: string;
+  budgetedAmount: string;
+  actualAmount: string;
+  /** Absolute variance: actual − budgeted (positive = over budget). */
+  varianceAmount: string;
+  /** Variance as a percentage of budgeted amount (decimal string). */
+  variancePct: string;
+  /** Whether actual spend exceeds the budgeted amount. */
+  isOverBudget: boolean;
+  currency: string;
+}
+
+export interface BudgetVarianceResult {
+  items: BudgetVarianceItem[];
+  /** Total budgeted across all items. */
+  totalBudgeted: string;
+  /** Total actual across all items. */
+  totalActual: string;
+  /** Total variance: totalActual − totalBudgeted. */
+  totalVariance: string;
+  /** Portfolio-level variance percentage. */
+  totalVariancePct: string;
+  /** True if totalActual > totalBudgeted. */
+  isOverBudget: boolean;
+  currency: string;
+  formulasApplied: string[];
+  warnings: string[];
+}
+
+// ─── Spend data point (for trend / forecasting) ───────────────────────────────
+
+/**
+ * A historical spend observation for a single period.
+ */
+export interface SpendDataPoint {
+  /** ISO 8601 period label, e.g. "2026-01", "2026-Q1". */
+  periodLabel: string;
+  /** Actual spend in this period (decimal string). */
+  amount: string;
+}
+
+// ─── Trend extrapolation ──────────────────────────────────────────────────────
+
+export type TrendMethod =
+  | "linear"        // Ordinary least-squares linear regression on period index
+  | "moving-average"; // Simple moving average of last N observations
+
+export interface TrendExtrapolationInput {
+  /** Historical spend observations in chronological order (oldest first). */
+  dataPoints: SpendDataPoint[];
+  /** Number of future periods to forecast. */
+  forecastPeriods: number;
+  /** Extrapolation method. Defaults to "linear". */
+  method?: TrendMethod;
+  /** Window size for moving-average method (default: all available points). */
+  movingAverageWindow?: number;
+  /** ISO 4217 currency. */
+  currency: string;
+}
+
+export interface ForecastDataPoint {
+  /** 1-based index of the forecast period (1 = next period after last observation). */
+  periodIndex: number;
+  /** Estimated spend (decimal string). Clamped to ≥ 0. */
+  forecastedAmount: string;
+}
+
+export interface TrendExtrapolationResult {
+  method: TrendMethod;
+  /** Slope per period (linear only; "0" for moving-average). */
+  slopePerPeriod: string;
+  /** Intercept (linear only; "0" for moving-average). */
+  intercept: string;
+  /** Average of the moving window (moving-average only; "0" for linear). */
+  movingAverage: string;
+  /** R² goodness-of-fit (linear only; 0–1; "0" for moving-average). */
+  rSquared: string;
+  forecasts: ForecastDataPoint[];
+  currency: string;
+  formulasApplied: string[];
+  warnings: string[];
+}
+
+// ─── Budget projection ────────────────────────────────────────────────────────
+
+export interface BudgetProjectionInput {
+  /** Baseline spend for the current period (decimal string). */
+  baselineAmount: string;
+  /** Percentage growth rate per period (e.g. "5" = 5% per period). Can be negative. */
+  growthRatePct: string;
+  /** Number of future periods to project. */
+  periods: number;
+  /** Period granularity (used for labeling only). */
+  period: Period;
+  /** ISO 4217 currency. */
+  currency: string;
+}
+
+export interface ProjectedPeriod {
+  /** 1-based period index. */
+  periodIndex: number;
+  /** Projected spend for this period (decimal string). */
+  projectedAmount: string;
+  /** Cumulative projected spend up to and including this period (decimal string). */
+  cumulativeAmount: string;
+}
+
+export interface BudgetProjectionResult {
+  baselineAmount: string;
+  growthRatePct: string;
+  periods: ProjectedPeriod[];
+  /** Total projected spend across all periods (decimal string). */
+  totalProjected: string;
+  currency: string;
+  period: Period;
+  formulasApplied: string[];
+  warnings: string[];
+}

--- a/packages/budgeting-forecasting/tests/engine.test.ts
+++ b/packages/budgeting-forecasting/tests/engine.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeBudgetVariance,
+  extrapolateTrend,
+  projectBudget,
+} from "../src/index.js";
+import type { BudgetLineItem, SpendDataPoint } from "../src/index.js";
+
+// ─── computeBudgetVariance ────────────────────────────────────────────────────
+
+describe("computeBudgetVariance", () => {
+  const items: BudgetLineItem[] = [
+    { id: "compute", label: "Compute", budgetedAmount: "10000", actualAmount: "11500", currency: "USD" },
+    { id: "storage", label: "Storage", budgetedAmount: "2000",  actualAmount: "1800",  currency: "USD" },
+    { id: "network", label: "Network", budgetedAmount: "500",   actualAmount: "500",   currency: "USD" },
+  ];
+
+  it("computes per-item variance amounts correctly", () => {
+    const r = computeBudgetVariance(items, "USD");
+    expect(r.items[0]!.varianceAmount).toBe("1500.0000000000");  // over
+    expect(r.items[1]!.varianceAmount).toBe("-200.0000000000");  // under
+    expect(r.items[2]!.varianceAmount).toBe("0.0000000000");    // on budget
+  });
+
+  it("identifies over-budget items", () => {
+    const r = computeBudgetVariance(items, "USD");
+    expect(r.items[0]!.isOverBudget).toBe(true);
+    expect(r.items[1]!.isOverBudget).toBe(false);
+    expect(r.items[2]!.isOverBudget).toBe(false);
+  });
+
+  it("computes per-item variance percentage", () => {
+    const r = computeBudgetVariance(items, "USD");
+    // compute: 1500/10000 × 100 = 15%
+    expect(parseFloat(r.items[0]!.variancePct)).toBeCloseTo(15, 5);
+    // storage: -200/2000 × 100 = -10%
+    expect(parseFloat(r.items[1]!.variancePct)).toBeCloseTo(-10, 5);
+    // network: 0/500 × 100 = 0%
+    expect(parseFloat(r.items[2]!.variancePct)).toBeCloseTo(0, 5);
+  });
+
+  it("computes correct portfolio totals", () => {
+    const r = computeBudgetVariance(items, "USD");
+    expect(r.totalBudgeted).toBe("12500.0000000000");
+    expect(r.totalActual).toBe("13800.0000000000");
+    expect(r.totalVariance).toBe("1300.0000000000");
+    expect(r.isOverBudget).toBe(true);
+  });
+
+  it("portfolio variance pct: 1300/12500 × 100 = 10.4%", () => {
+    const r = computeBudgetVariance(items, "USD");
+    expect(parseFloat(r.totalVariancePct)).toBeCloseTo(10.4, 4);
+  });
+
+  it("portfolio under budget when all items under", () => {
+    const under: BudgetLineItem[] = [
+      { id: "a", label: "A", budgetedAmount: "1000", actualAmount: "800", currency: "USD" },
+      { id: "b", label: "B", budgetedAmount: "500",  actualAmount: "400", currency: "USD" },
+    ];
+    const r = computeBudgetVariance(under, "USD");
+    expect(r.isOverBudget).toBe(false);
+    expect(r.totalVariance).toBe("-300.0000000000");
+  });
+
+  it("handles zero budgeted amount without dividing by zero", () => {
+    const zero: BudgetLineItem[] = [
+      { id: "free", label: "Free tier", budgetedAmount: "0", actualAmount: "50", currency: "USD" },
+    ];
+    const r = computeBudgetVariance(zero, "USD");
+    expect(r.items[0]!.variancePct).toBe("0.0000000000");
+    expect(r.items[0]!.isOverBudget).toBe(true);
+  });
+
+  it("empty items produces empty result with warning", () => {
+    const r = computeBudgetVariance([], "USD");
+    expect(r.items).toHaveLength(0);
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(r.totalBudgeted).toBe("0.0000000000");
+  });
+
+  it("includes formulasApplied", () => {
+    const r = computeBudgetVariance(items, "USD");
+    expect(r.formulasApplied).toContain("budget.variance.item");
+    expect(r.formulasApplied).toContain("budget.variance.portfolio");
+  });
+});
+
+// ─── extrapolateTrend — linear ────────────────────────────────────────────────
+
+describe("extrapolateTrend (linear)", () => {
+  // Perfectly linear data: 100, 200, 300, 400, 500 (slope = 100, intercept = 0)
+  const linearPoints: SpendDataPoint[] = [
+    { periodLabel: "2025-01", amount: "100" },
+    { periodLabel: "2025-02", amount: "200" },
+    { periodLabel: "2025-03", amount: "300" },
+    { periodLabel: "2025-04", amount: "400" },
+    { periodLabel: "2025-05", amount: "500" },
+  ];
+
+  it("slope is ~100 for perfectly linear data", () => {
+    const r = extrapolateTrend({ dataPoints: linearPoints, forecastPeriods: 1, currency: "USD" });
+    expect(parseFloat(r.slopePerPeriod)).toBeCloseTo(100, 3);
+  });
+
+  it("R² is 1.0 for perfectly linear data", () => {
+    const r = extrapolateTrend({ dataPoints: linearPoints, forecastPeriods: 1, currency: "USD" });
+    expect(parseFloat(r.rSquared)).toBeCloseTo(1.0, 5);
+  });
+
+  it("forecasts next 3 periods correctly (600, 700, 800)", () => {
+    const r = extrapolateTrend({ dataPoints: linearPoints, forecastPeriods: 3, currency: "USD" });
+    expect(r.forecasts).toHaveLength(3);
+    expect(parseFloat(r.forecasts[0]!.forecastedAmount)).toBeCloseTo(600, 1);
+    expect(parseFloat(r.forecasts[1]!.forecastedAmount)).toBeCloseTo(700, 1);
+    expect(parseFloat(r.forecasts[2]!.forecastedAmount)).toBeCloseTo(800, 1);
+  });
+
+  it("forecast amounts are non-negative (clamped)", () => {
+    const declining: SpendDataPoint[] = [
+      { periodLabel: "2025-01", amount: "100" },
+      { periodLabel: "2025-02", amount: "50" },
+      { periodLabel: "2025-03", amount: "10" },
+    ];
+    const r = extrapolateTrend({ dataPoints: declining, forecastPeriods: 10, currency: "USD" });
+    r.forecasts.forEach((f) => {
+      expect(parseFloat(f.forecastedAmount)).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it("includes formulasApplied for linear", () => {
+    const r = extrapolateTrend({ dataPoints: linearPoints, forecastPeriods: 2, currency: "USD" });
+    expect(r.formulasApplied).toContain("forecast.trend.linear");
+    expect(r.formulasApplied).toContain("forecast.trend.rSquared");
+  });
+
+  it("empty data points produce all-zero forecasts with warning", () => {
+    const r = extrapolateTrend({ dataPoints: [], forecastPeriods: 3, currency: "USD" });
+    expect(r.warnings.length).toBeGreaterThan(0);
+    r.forecasts.forEach((f) => expect(f.forecastedAmount).toBe("0.0000000000"));
+  });
+
+  it("single data point: slope=0, forecast = that value", () => {
+    const r = extrapolateTrend({
+      dataPoints: [{ periodLabel: "2025-01", amount: "500" }],
+      forecastPeriods: 2,
+      currency: "USD",
+    });
+    expect(r.warnings.length).toBeGreaterThan(0); // degenerate data warning
+    r.forecasts.forEach((f) => {
+      expect(parseFloat(f.forecastedAmount)).toBeCloseTo(500, 3);
+    });
+  });
+});
+
+// ─── extrapolateTrend — moving-average ────────────────────────────────────────
+
+describe("extrapolateTrend (moving-average)", () => {
+  const points: SpendDataPoint[] = [
+    { periodLabel: "2025-01", amount: "100" },
+    { periodLabel: "2025-02", amount: "200" },
+    { periodLabel: "2025-03", amount: "300" },
+    { periodLabel: "2025-04", amount: "400" },
+  ];
+
+  it("3-period moving average of last 3 = (200+300+400)/3 = 300", () => {
+    const r = extrapolateTrend({
+      dataPoints: points,
+      forecastPeriods: 2,
+      method: "moving-average",
+      movingAverageWindow: 3,
+      currency: "USD",
+    });
+    const avg = parseFloat(r.movingAverage);
+    expect(avg).toBeCloseTo(300, 3);
+    r.forecasts.forEach((f) => expect(parseFloat(f.forecastedAmount)).toBeCloseTo(300, 3));
+  });
+
+  it("full-window average = (100+200+300+400)/4 = 250", () => {
+    const r = extrapolateTrend({
+      dataPoints: points,
+      forecastPeriods: 1,
+      method: "moving-average",
+      currency: "USD",
+    });
+    expect(parseFloat(r.movingAverage)).toBeCloseTo(250, 3);
+  });
+
+  it("window larger than data warns and uses all points", () => {
+    const r = extrapolateTrend({
+      dataPoints: points,
+      forecastPeriods: 1,
+      method: "moving-average",
+      movingAverageWindow: 100,
+      currency: "USD",
+    });
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(parseFloat(r.movingAverage)).toBeCloseTo(250, 3);
+  });
+
+  it("includes formulasApplied for moving-average", () => {
+    const r = extrapolateTrend({
+      dataPoints: points,
+      forecastPeriods: 1,
+      method: "moving-average",
+      currency: "USD",
+    });
+    expect(r.formulasApplied).toContain("forecast.trend.movingAverage");
+  });
+});
+
+// ─── projectBudget ────────────────────────────────────────────────────────────
+
+describe("projectBudget", () => {
+  it("5% growth on $10k baseline for 3 periods", () => {
+    const r = projectBudget({
+      baselineAmount: "10000",
+      growthRatePct: "5",
+      periods: 3,
+      period: "monthly",
+      currency: "USD",
+    });
+    expect(r.periods).toHaveLength(3);
+    // period 1: 10000 × 1.05^1 = 10500
+    expect(parseFloat(r.periods[0]!.projectedAmount)).toBeCloseTo(10500, 2);
+    // period 2: 10000 × 1.05^2 = 11025
+    expect(parseFloat(r.periods[1]!.projectedAmount)).toBeCloseTo(11025, 2);
+    // period 3: 10000 × 1.05^3 = 11576.25
+    expect(parseFloat(r.periods[2]!.projectedAmount)).toBeCloseTo(11576.25, 2);
+  });
+
+  it("cumulative amounts accumulate correctly", () => {
+    const r = projectBudget({
+      baselineAmount: "10000",
+      growthRatePct: "5",
+      periods: 3,
+      period: "monthly",
+      currency: "USD",
+    });
+    // cumulative[2] = cumulative[1] + projected[2]
+    const cum1 = parseFloat(r.periods[0]!.cumulativeAmount);
+    const cum2 = parseFloat(r.periods[1]!.cumulativeAmount);
+    const proj2 = parseFloat(r.periods[1]!.projectedAmount);
+    expect(cum2).toBeCloseTo(cum1 + proj2, 3);
+  });
+
+  it("totalProjected equals last period cumulativeAmount", () => {
+    const r = projectBudget({
+      baselineAmount: "5000",
+      growthRatePct: "10",
+      periods: 4,
+      period: "quarterly",
+      currency: "USD",
+    });
+    const lastCumulative = parseFloat(r.periods[3]!.cumulativeAmount);
+    expect(parseFloat(r.totalProjected)).toBeCloseTo(lastCumulative, 5);
+  });
+
+  it("0% growth = constant baseline each period", () => {
+    const r = projectBudget({
+      baselineAmount: "8000",
+      growthRatePct: "0",
+      periods: 3,
+      period: "monthly",
+      currency: "USD",
+    });
+    r.periods.forEach((p) => {
+      expect(parseFloat(p.projectedAmount)).toBeCloseTo(8000, 5);
+    });
+  });
+
+  it("negative growth rate (cost reduction scenario)", () => {
+    const r = projectBudget({
+      baselineAmount: "10000",
+      growthRatePct: "-10",
+      periods: 2,
+      period: "monthly",
+      currency: "USD",
+    });
+    // period 1: 10000 × 0.9 = 9000
+    expect(parseFloat(r.periods[0]!.projectedAmount)).toBeCloseTo(9000, 2);
+    // period 2: 10000 × 0.81 = 8100
+    expect(parseFloat(r.periods[1]!.projectedAmount)).toBeCloseTo(8100, 2);
+  });
+
+  it("includes formulasApplied", () => {
+    const r = projectBudget({
+      baselineAmount: "1000",
+      growthRatePct: "5",
+      periods: 1,
+      period: "monthly",
+      currency: "USD",
+    });
+    expect(r.formulasApplied).toContain("budget.projection.compoundGrowth");
+  });
+
+  it("periods < 1 warned and defaults to 1", () => {
+    const r = projectBudget({
+      baselineAmount: "1000",
+      growthRatePct: "5",
+      periods: 0,
+      period: "monthly",
+      currency: "USD",
+    });
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(r.periods).toHaveLength(1);
+  });
+});

--- a/packages/budgeting-forecasting/tsconfig.json
+++ b/packages/budgeting-forecasting/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,19 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.15)
 
+  packages/budgeting-forecasting:
+    dependencies:
+      '@ficecal/core-economics':
+        specifier: workspace:*
+        version: link:../core-economics
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.19.15)
+
   packages/chart-presentation:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
- New package `@ficecal/budgeting-forecasting` — Phase 2 financial planning engine
- `computeBudgetVariance`: per-item and portfolio variance (absolute + %), over-budget flags
- `extrapolateTrend`: linear OLS (R², slope, intercept) and moving-average; future spend forecasts clamped ≥ 0
- `projectBudget`: compound growth projection with per-period and cumulative totals
- 27 vitest tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added budget variance analysis to compare budgeted and actual spending amounts with detailed variance calculations
  * Added trend forecasting capabilities for historical spending data using multiple analysis methods
  * Added budget projection with customizable growth rate modeling across multiple periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->