### PR TITLE
feat(reference-evidence): Phase 2 queryable evidence catalog with framework citations

### DIFF
--- a/packages/reference-evidence/package.json
+++ b/packages/reference-evidence/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@ficecal/reference-evidence",
+  "version": "1.0.0",
+  "description": "FiceCal v2 — explanatory evidence library: framework citations, methodology notes, and source references for recommendations and calculations",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.1",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/reference-evidence/src/catalog.ts
+++ b/packages/reference-evidence/src/catalog.ts
@@ -1,0 +1,173 @@
+import type { EvidenceEntry } from "./types.js";
+
+/**
+ * Canonical evidence catalog for FiceCal v2.
+ *
+ * Each entry explains the authoritative basis for one or more calculation
+ * methodologies or recommendation thresholds used in FiceCal v2.
+ *
+ * Versioning: entries are append-only; deprecated entries gain a "deprecated"
+ * tag rather than being removed so existing formula references remain resolvable.
+ */
+export const EVIDENCE_CATALOG: EvidenceEntry[] = [
+  // ─── FinOps / FOCUS ───────────────────────────────────────────────────────
+
+  {
+    id: "focus-1.3-cost-allocation",
+    title: "FOCUS 1.3 — Cost and Usage Specification",
+    sourceType: "standard",
+    source: "FinOps Foundation",
+    version: "1.3",
+    url: "https://focus.finops.org/",
+    rationale:
+      "FOCUS 1.3 defines the canonical columns and semantics for cloud cost and usage data. " +
+      "FiceCal v2 uses FOCUS column names (BilledCost, EffectiveCost, ChargePeriodStart) as " +
+      "the normalisation target when ingesting multi-cloud billing exports, ensuring " +
+      "vendor-agnostic cost comparisons.",
+    appliesTo: ["budget.variance.item", "budget.variance.portfolio", "tech.normalize.perUnit"],
+    tags: ["FinOps", "FOCUS", "cost-allocation", "multi-cloud"],
+  },
+  {
+    id: "finops-framework-2026",
+    title: "FinOps Framework 2026 — Capabilities and Domains",
+    sourceType: "framework",
+    source: "FinOps Foundation",
+    version: "2026",
+    url: "https://www.finops.org/framework/",
+    rationale:
+      "The FinOps Framework organises cloud financial management into six domains and 18 " +
+      "capabilities. FiceCal v2 maps its health-score signal categories to FinOps domains " +
+      "(Understand, Quantify, Optimise) to align recommendations with industry-standard " +
+      "maturity progression rather than arbitrary thresholds.",
+    appliesTo: ["health.score.weighted", "recommendation.rule.match"],
+    tags: ["FinOps", "framework", "maturity", "capability"],
+  },
+
+  // ─── SLO / Reliability ────────────────────────────────────────────────────
+
+  {
+    id: "google-sre-error-budget",
+    title: "Google SRE Book — Error Budgets",
+    sourceType: "methodology",
+    source: "Google SRE",
+    version: "2nd Edition",
+    url: "https://sre.google/sre-book/embracing-risk/",
+    rationale:
+      "The error budget concept — converting an SLO target into allowable downtime per " +
+      "period — originates in Google's SRE practice. FiceCal v2's computeErrorBudget " +
+      "implements this formula verbatim: allowableDowntime = totalMinutes × (1 − SLO%). " +
+      "The six canonical tiers (99% through 99.999%) reflect real-world SLA tiers cited " +
+      "across hyperscaler public commitments.",
+    appliesTo: [
+      "slo.errorBudget.allowableDowntime",
+      "slo.downtimeCost.revenue",
+      "slo.downtimeCost.engineering",
+    ],
+    tags: ["SLO", "SLA", "reliability", "error-budget", "SRE"],
+  },
+  {
+    id: "slo-reliability-roi",
+    title: "SRE Workbook — Setting SLOs",
+    sourceType: "methodology",
+    source: "Google SRE",
+    version: "1st Edition",
+    url: "https://sre.google/workbook/implementing-slos/",
+    rationale:
+      "The reliability ROI calculation (revenue protected per period ÷ improvement cost) " +
+      "provides a business justification for reliability investments. Payback period " +
+      "(improvement cost ÷ revenue protected) is the reciprocal and expresses break-even " +
+      "in billing periods. Both formulas are endorsed in the SRE Workbook's economic " +
+      "framework for SLO justification.",
+    appliesTo: ["slo.reliability.roi", "slo.reliability.payback"],
+    tags: ["SLO", "reliability", "ROI", "investment", "SRE"],
+  },
+
+  // ─── AI / Token pricing ───────────────────────────────────────────────────
+
+  {
+    id: "ai-token-billing-units",
+    title: "AI Model Pricing Unit Taxonomy — FiceCal v2 Internal",
+    sourceType: "methodology",
+    source: "FiceCal v2",
+    version: "1.0.0",
+    rationale:
+      "Different AI providers charge by different units: per individual token, per 1K tokens, " +
+      "per 1M tokens, per image, per API request, or per second of compute. FiceCal v2 " +
+      "normalises all six variants to a single decimal-safe cost result, enabling " +
+      "apples-to-apples comparisons across models from different vendors. The taxonomy " +
+      "is derived from a survey of AWS Bedrock, Anthropic, OpenAI, and Google Vertex AI " +
+      "public pricing pages as of 2026.",
+    appliesTo: ["aiCost.token", "aiCost.image", "aiCost.request", "aiCost.time"],
+    tags: ["AI", "tokens", "pricing", "LLM", "multi-model"],
+  },
+
+  // ─── Multi-technology normalisation ───────────────────────────────────────
+
+  {
+    id: "tech-normalization-basis-units",
+    title: "Cloud Pricing Basis Unit Normalisation — FiceCal v2 Internal",
+    sourceType: "methodology",
+    source: "FiceCal v2",
+    version: "1.0.0",
+    rationale:
+      "Comparing costs across cloud-compute ($/vCPU-hour), AI inference ($/1M tokens), " +
+      "SaaS licences ($/seat/month), and on-prem hardware ($/device) is impossible without " +
+      "normalisation to a canonical basis unit per category. FiceCal v2 defines 10 " +
+      "TechCategory variants, each with a documented basis unit and a median market benchmark " +
+      "derived from public vendor pricing. The efficiency index (costPerBasisUnit / median) " +
+      "enables relative spend health scoring across heterogeneous technology stacks.",
+    appliesTo: ["tech.normalize.perUnit", "tech.normalize.efficiencyIndex", "tech.normalize.portfolio"],
+    tags: ["normalization", "multi-cloud", "hybrid", "efficiency", "benchmark"],
+  },
+
+  // ─── Budget / Forecasting ─────────────────────────────────────────────────
+
+  {
+    id: "ols-linear-regression-forecast",
+    title: "Ordinary Least Squares Regression for Spend Forecasting",
+    sourceType: "methodology",
+    source: "FiceCal v2",
+    version: "1.0.0",
+    rationale:
+      "OLS linear regression fits a straight line (y = slope × x + intercept) to historical " +
+      "spend data indexed by period. The R² coefficient of determination measures goodness " +
+      "of fit; values close to 1.0 indicate the linear trend explains most of the observed " +
+      "variance. FiceCal v2 uses OLS as the default forecast method because it is " +
+      "interpretable, audit-friendly, and computationally lightweight for the small " +
+      "observation windows typical in cloud billing (6–24 months).",
+    appliesTo: ["forecast.trend.linear", "forecast.trend.rSquared"],
+    tags: ["forecasting", "regression", "OLS", "trend", "spend"],
+  },
+  {
+    id: "compound-growth-projection",
+    title: "Compound Growth Budget Projection",
+    sourceType: "methodology",
+    source: "FiceCal v2",
+    version: "1.0.0",
+    rationale:
+      "Budget projection using compound growth (projected = baseline × (1 + r)^n) is the " +
+      "standard approach for multi-period financial planning when a growth rate assumption " +
+      "is known. FiceCal v2 exposes the growth rate as an explicit input rather than " +
+      "inferring it from historical data, making the assumption transparent and auditable.",
+    appliesTo: ["budget.projection.compoundGrowth"],
+    tags: ["forecasting", "projection", "budget", "growth-rate"],
+  },
+
+  // ─── Health scoring ───────────────────────────────────────────────────────
+
+  {
+    id: "weighted-signal-health-score",
+    title: "Weighted Signal Aggregation for Cloud Health Scoring",
+    sourceType: "methodology",
+    source: "FiceCal v2",
+    version: "1.0.0",
+    rationale:
+      "FiceCal v2's health score is computed as a weighted average of normalised signal " +
+      "scores across six categories (pricing-freshness, budget-adherence, model-trust, etc.). " +
+      "The worst-severity propagation rule ensures that a single critical signal can cap the " +
+      "overall score, preventing a high average from masking a severe outlier. This approach " +
+      "is consistent with composite index design patterns used in financial risk scoring.",
+    appliesTo: ["health.score.weighted", "health.score.worstSeverity"],
+    tags: ["health-score", "reliability", "composite-index", "risk"],
+  },
+];

--- a/packages/reference-evidence/src/index.ts
+++ b/packages/reference-evidence/src/index.ts
@@ -1,0 +1,15 @@
+export type {
+  EvidenceSourceType,
+  EvidenceEntry,
+  EvidenceQuery,
+  EvidenceQueryResult,
+} from "./types.js";
+
+export { EVIDENCE_CATALOG } from "./catalog.js";
+
+export {
+  queryEvidence,
+  getEvidenceById,
+  getEvidenceForFormula,
+  getAllEvidence,
+} from "./query.js";

--- a/packages/reference-evidence/src/query.ts
+++ b/packages/reference-evidence/src/query.ts
@@ -1,0 +1,77 @@
+import { EVIDENCE_CATALOG } from "./catalog.js";
+import type {
+  EvidenceEntry,
+  EvidenceQuery,
+  EvidenceQueryResult,
+} from "./types.js";
+
+// ─── Query engine ─────────────────────────────────────────────────────────────
+
+/**
+ * Query the evidence catalog with optional filters.
+ *
+ * All filters are applied with AND semantics:
+ * - sourceType: exact match
+ * - formulaKeys: entry.appliesTo must contain at least one of the given keys
+ * - tags: entry.tags must contain ALL of the given tags
+ * - search: case-insensitive substring across title + rationale + source
+ */
+export function queryEvidence(query: EvidenceQuery = {}): EvidenceQueryResult {
+  let results: EvidenceEntry[] = [...EVIDENCE_CATALOG];
+
+  if (query.sourceType !== undefined) {
+    results = results.filter((e) => e.sourceType === query.sourceType);
+  }
+
+  if (query.formulaKeys !== undefined && query.formulaKeys.length > 0) {
+    const keys = new Set(query.formulaKeys);
+    results = results.filter((e) => e.appliesTo.some((k) => keys.has(k)));
+  }
+
+  if (query.tags !== undefined && query.tags.length > 0) {
+    const requiredTags = query.tags.map((t) => t.toLowerCase());
+    results = results.filter((e) => {
+      const entryTags = e.tags.map((t) => t.toLowerCase());
+      return requiredTags.every((rt) => entryTags.includes(rt));
+    });
+  }
+
+  if (query.search !== undefined && query.search.trim().length > 0) {
+    const needle = query.search.toLowerCase();
+    results = results.filter(
+      (e) =>
+        e.title.toLowerCase().includes(needle) ||
+        e.rationale.toLowerCase().includes(needle) ||
+        e.source.toLowerCase().includes(needle),
+    );
+  }
+
+  return {
+    entries: results,
+    totalMatched: results.length,
+    query,
+  };
+}
+
+/**
+ * Look up a single evidence entry by its stable id.
+ * Returns undefined if not found.
+ */
+export function getEvidenceById(id: string): EvidenceEntry | undefined {
+  return EVIDENCE_CATALOG.find((e) => e.id === id);
+}
+
+/**
+ * Return all evidence entries whose appliesTo includes the given formula key.
+ * Convenience wrapper around queryEvidence.
+ */
+export function getEvidenceForFormula(formulaKey: string): EvidenceEntry[] {
+  return queryEvidence({ formulaKeys: [formulaKey] }).entries;
+}
+
+/**
+ * Return the complete catalog (no filters applied).
+ */
+export function getAllEvidence(): EvidenceEntry[] {
+  return [...EVIDENCE_CATALOG];
+}

--- a/packages/reference-evidence/src/types.ts
+++ b/packages/reference-evidence/src/types.ts
@@ -1,0 +1,87 @@
+// ─── Evidence source ──────────────────────────────────────────────────────────
+
+/**
+ * The authoritative source type for an evidence entry.
+ * Drives display treatment and link handling.
+ */
+export type EvidenceSourceType =
+  | "framework"     // Industry framework (FOCUS, FinOps, ITIL, etc.)
+  | "standard"      // Published standard (ISO, NIST, CNCF, etc.)
+  | "methodology"   // Internal or vendor methodology
+  | "benchmark"     // Published benchmark or survey data
+  | "regulation"    // Regulatory / compliance requirement
+  | "best-practice"; // Community or vendor best-practice guide
+
+/**
+ * A citable evidence entry explaining the rationale behind a calculation,
+ * recommendation, or threshold used in FiceCal v2.
+ */
+export interface EvidenceEntry {
+  /** Stable unique identifier, e.g. "focus-1.3-cost-allocation". */
+  id: string;
+
+  /** Short display title. */
+  title: string;
+
+  /** Source type for categorization and display treatment. */
+  sourceType: EvidenceSourceType;
+
+  /**
+   * Name of the authoritative body or framework.
+   * e.g. "FinOps Foundation", "NIST", "Google SRE"
+   */
+  source: string;
+
+  /**
+   * Specific version or edition of the source, if applicable.
+   * e.g. "1.3", "2026", "4th Edition"
+   */
+  version?: string;
+
+  /**
+   * URL to the primary reference document.
+   * May be undefined for internal methodologies.
+   */
+  url?: string;
+
+  /**
+   * One-paragraph explanation of what this evidence supports and why it was
+   * chosen for FiceCal v2.
+   */
+  rationale: string;
+
+  /**
+   * Which calculation or recommendation formula keys this evidence supports.
+   * Mirrors the `formulasApplied` keys from engine results.
+   * e.g. ["slo.errorBudget.allowableDowntime", "slo.reliability.roi"]
+   */
+  appliesTo: string[];
+
+  /**
+   * Free-text tags for filtering in UI.
+   * e.g. ["SLO", "reliability", "FinOps"]
+   */
+  tags: string[];
+}
+
+// ─── Evidence query ───────────────────────────────────────────────────────────
+
+export interface EvidenceQuery {
+  /** Filter by source type. */
+  sourceType?: EvidenceSourceType;
+
+  /** Return only entries whose appliesTo intersects this set. */
+  formulaKeys?: string[];
+
+  /** Return only entries containing all of these tags. */
+  tags?: string[];
+
+  /** Free-text search across title, rationale, source. Case-insensitive. */
+  search?: string;
+}
+
+export interface EvidenceQueryResult {
+  entries: EvidenceEntry[];
+  totalMatched: number;
+  query: EvidenceQuery;
+}

--- a/packages/reference-evidence/tests/query.test.ts
+++ b/packages/reference-evidence/tests/query.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import {
+  EVIDENCE_CATALOG,
+  queryEvidence,
+  getEvidenceById,
+  getEvidenceForFormula,
+  getAllEvidence,
+} from "../src/index.js";
+
+// ─── EVIDENCE_CATALOG ─────────────────────────────────────────────────────────
+
+describe("EVIDENCE_CATALOG", () => {
+  it("contains at least 8 entries", () => {
+    expect(EVIDENCE_CATALOG.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("every entry has required fields", () => {
+    EVIDENCE_CATALOG.forEach((e) => {
+      expect(e.id.length).toBeGreaterThan(0);
+      expect(e.title.length).toBeGreaterThan(0);
+      expect(e.source.length).toBeGreaterThan(0);
+      expect(e.rationale.length).toBeGreaterThan(0);
+      expect(e.appliesTo.length).toBeGreaterThan(0);
+      expect(e.tags.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("all ids are unique", () => {
+    const ids = EVIDENCE_CATALOG.map((e) => e.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it("contains FOCUS 1.3 entry", () => {
+    expect(EVIDENCE_CATALOG.some((e) => e.id === "focus-1.3-cost-allocation")).toBe(true);
+  });
+
+  it("contains Google SRE error budget entry", () => {
+    expect(EVIDENCE_CATALOG.some((e) => e.id === "google-sre-error-budget")).toBe(true);
+  });
+});
+
+// ─── getAllEvidence ───────────────────────────────────────────────────────────
+
+describe("getAllEvidence", () => {
+  it("returns all catalog entries", () => {
+    expect(getAllEvidence().length).toBe(EVIDENCE_CATALOG.length);
+  });
+
+  it("returns a copy, not the original array", () => {
+    const result = getAllEvidence();
+    result.push({} as never);
+    expect(getAllEvidence().length).toBe(EVIDENCE_CATALOG.length);
+  });
+});
+
+// ─── getEvidenceById ──────────────────────────────────────────────────────────
+
+describe("getEvidenceById", () => {
+  it("finds an entry by exact id", () => {
+    const e = getEvidenceById("google-sre-error-budget");
+    expect(e).toBeDefined();
+    expect(e!.id).toBe("google-sre-error-budget");
+  });
+
+  it("returns undefined for unknown id", () => {
+    expect(getEvidenceById("does-not-exist")).toBeUndefined();
+  });
+
+  it("finds FOCUS entry", () => {
+    const e = getEvidenceById("focus-1.3-cost-allocation");
+    expect(e!.sourceType).toBe("standard");
+    expect(e!.version).toBe("1.3");
+  });
+});
+
+// ─── getEvidenceForFormula ────────────────────────────────────────────────────
+
+describe("getEvidenceForFormula", () => {
+  it("finds evidence for slo.errorBudget.allowableDowntime", () => {
+    const entries = getEvidenceForFormula("slo.errorBudget.allowableDowntime");
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries.some((e) => e.id === "google-sre-error-budget")).toBe(true);
+  });
+
+  it("finds evidence for slo.reliability.roi", () => {
+    const entries = getEvidenceForFormula("slo.reliability.roi");
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries.some((e) => e.id === "slo-reliability-roi")).toBe(true);
+  });
+
+  it("finds evidence for budget.projection.compoundGrowth", () => {
+    const entries = getEvidenceForFormula("budget.projection.compoundGrowth");
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty array for unknown formula key", () => {
+    expect(getEvidenceForFormula("does.not.exist")).toHaveLength(0);
+  });
+
+  it("finds evidence for forecast.trend.linear", () => {
+    const entries = getEvidenceForFormula("forecast.trend.linear");
+    expect(entries.some((e) => e.id === "ols-linear-regression-forecast")).toBe(true);
+  });
+});
+
+// ─── queryEvidence — no filters ───────────────────────────────────────────────
+
+describe("queryEvidence (no filter)", () => {
+  it("returns all entries when no filter given", () => {
+    const r = queryEvidence();
+    expect(r.entries.length).toBe(EVIDENCE_CATALOG.length);
+    expect(r.totalMatched).toBe(EVIDENCE_CATALOG.length);
+  });
+});
+
+// ─── queryEvidence — sourceType filter ───────────────────────────────────────
+
+describe("queryEvidence (sourceType)", () => {
+  it("filters by sourceType=methodology", () => {
+    const r = queryEvidence({ sourceType: "methodology" });
+    r.entries.forEach((e) => expect(e.sourceType).toBe("methodology"));
+    expect(r.entries.length).toBeGreaterThan(0);
+  });
+
+  it("filters by sourceType=standard", () => {
+    const r = queryEvidence({ sourceType: "standard" });
+    r.entries.forEach((e) => expect(e.sourceType).toBe("standard"));
+    // FOCUS is a standard
+    expect(r.entries.some((e) => e.id === "focus-1.3-cost-allocation")).toBe(true);
+  });
+
+  it("filters by sourceType=framework", () => {
+    const r = queryEvidence({ sourceType: "framework" });
+    r.entries.forEach((e) => expect(e.sourceType).toBe("framework"));
+    expect(r.entries.some((e) => e.id === "finops-framework-2026")).toBe(true);
+  });
+
+  it("returns empty for sourceType with no entries", () => {
+    const r = queryEvidence({ sourceType: "regulation" });
+    expect(r.entries).toHaveLength(0);
+  });
+});
+
+// ─── queryEvidence — formulaKeys filter ──────────────────────────────────────
+
+describe("queryEvidence (formulaKeys)", () => {
+  it("returns entries applying to given formula key", () => {
+    const r = queryEvidence({ formulaKeys: ["slo.errorBudget.allowableDowntime"] });
+    expect(r.entries.length).toBeGreaterThan(0);
+    r.entries.forEach((e) =>
+      expect(e.appliesTo).toContain("slo.errorBudget.allowableDowntime"),
+    );
+  });
+
+  it("matches any of multiple formula keys (OR semantics)", () => {
+    const r = queryEvidence({ formulaKeys: ["slo.reliability.roi", "forecast.trend.linear"] });
+    expect(r.entries.length).toBeGreaterThanOrEqual(2);
+    r.entries.forEach((e) => {
+      const hasAny = e.appliesTo.includes("slo.reliability.roi") ||
+                     e.appliesTo.includes("forecast.trend.linear");
+      expect(hasAny).toBe(true);
+    });
+  });
+
+  it("empty formulaKeys does not filter", () => {
+    const r = queryEvidence({ formulaKeys: [] });
+    expect(r.entries.length).toBe(EVIDENCE_CATALOG.length);
+  });
+});
+
+// ─── queryEvidence — tags filter ──────────────────────────────────────────────
+
+describe("queryEvidence (tags)", () => {
+  it("filters by single tag", () => {
+    const r = queryEvidence({ tags: ["SLO"] });
+    expect(r.entries.length).toBeGreaterThan(0);
+    r.entries.forEach((e) =>
+      expect(e.tags.map((t) => t.toLowerCase())).toContain("slo"),
+    );
+  });
+
+  it("requires ALL tags (AND semantics)", () => {
+    const r = queryEvidence({ tags: ["SLO", "ROI"] });
+    r.entries.forEach((e) => {
+      const lower = e.tags.map((t) => t.toLowerCase());
+      expect(lower).toContain("slo");
+      expect(lower).toContain("roi");
+    });
+  });
+
+  it("tag matching is case-insensitive", () => {
+    const r1 = queryEvidence({ tags: ["finops"] });
+    const r2 = queryEvidence({ tags: ["FinOps"] });
+    expect(r1.totalMatched).toBe(r2.totalMatched);
+  });
+
+  it("returns empty for combination that matches nothing", () => {
+    const r = queryEvidence({ tags: ["SLO", "AI"] });
+    expect(r.entries).toHaveLength(0);
+  });
+});
+
+// ─── queryEvidence — search filter ───────────────────────────────────────────
+
+describe("queryEvidence (search)", () => {
+  it("searches in title", () => {
+    const r = queryEvidence({ search: "Error Budget" });
+    expect(r.entries.length).toBeGreaterThan(0);
+    r.entries.forEach((e) =>
+      expect(
+        e.title.toLowerCase().includes("error budget") ||
+        e.rationale.toLowerCase().includes("error budget") ||
+        e.source.toLowerCase().includes("error budget"),
+      ).toBe(true),
+    );
+  });
+
+  it("search is case-insensitive", () => {
+    const r1 = queryEvidence({ search: "google sre" });
+    const r2 = queryEvidence({ search: "Google SRE" });
+    expect(r1.totalMatched).toBe(r2.totalMatched);
+  });
+
+  it("searches in rationale", () => {
+    const r = queryEvidence({ search: "decimal-safe" });
+    expect(r.entries.length).toBeGreaterThan(0);
+  });
+
+  it("empty search string does not filter", () => {
+    const r = queryEvidence({ search: "  " });
+    expect(r.entries.length).toBe(EVIDENCE_CATALOG.length);
+  });
+
+  it("returns empty for search term with no matches", () => {
+    const r = queryEvidence({ search: "xyzzy-nonexistent-term-9999" });
+    expect(r.entries).toHaveLength(0);
+  });
+});
+
+// ─── queryEvidence — combined filters ────────────────────────────────────────
+
+describe("queryEvidence (combined filters)", () => {
+  it("sourceType + formulaKeys combined (AND semantics)", () => {
+    const r = queryEvidence({
+      sourceType: "methodology",
+      formulaKeys: ["slo.errorBudget.allowableDowntime"],
+    });
+    r.entries.forEach((e) => {
+      expect(e.sourceType).toBe("methodology");
+      expect(e.appliesTo).toContain("slo.errorBudget.allowableDowntime");
+    });
+  });
+
+  it("query object preserved on result", () => {
+    const q = { sourceType: "standard" as const, tags: ["FinOps"] };
+    const r = queryEvidence(q);
+    expect(r.query).toEqual(q);
+  });
+});

--- a/packages/reference-evidence/tsconfig.json
+++ b/packages/reference-evidence/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,15 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.15)
 
+  packages/reference-evidence:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.19.15)
+
   packages/sla-slo-sli-economics:
     dependencies:
       '@ficecal/core-economics':


### PR DESCRIPTION
## Summary
- New package `@ficecal/reference-evidence` — citable rationale for every FiceCal v2 calculation
- `EvidenceEntry` type with stable id, sourceType (framework/standard/methodology/benchmark/regulation/best-practice), appliesTo formula keys, and tags
- `EVIDENCE_CATALOG`: 8 entries covering FOCUS 1.3, FinOps Framework 2026, Google SRE error budgets, reliability ROI, AI token pricing, multi-tech normalisation, OLS regression, compound growth
- `queryEvidence()`: AND-semantic filter by sourceType, formulaKeys (OR), tags (AND), free-text search
- 34 vitest tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)