### PR TITLE
feat(web): Phase 4 production wiring — single-page layout, D3 charts, live economics

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,11 +15,17 @@
     "@ficecal/core-economics": "workspace:*",
     "@ficecal/health-score": "workspace:*",
     "@ficecal/recommendation-module": "workspace:*",
+    "@ficecal/budgeting-forecasting": "workspace:*",
+    "@ficecal/chart-presentation": "workspace:*",
+    "@ficecal/demo-scenarios": "workspace:*",
+    "@ficecal/multi-tech-normalization": "workspace:*",
     "@ficecal/ui-foundation": "workspace:*",
+    "d3": "^7.9.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
+    "@types/d3": "^7.4.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,9 @@
+// ─── App ──────────────────────────────────────────────────────────────────────
+//
+// Phase 4: full single-page layout — all four panels visible simultaneously,
+// NavBar for smooth-scroll anchoring, ScenarioBar for preset loading,
+// economicsResult lifted from CostEstimator into HealthDashboard.
+
 import { useState, useEffect } from "react";
 import type { SharedContext } from "./types.js";
 import { useUiFoundation } from "./hooks/useUiFoundation.js";
@@ -5,9 +11,10 @@ import { SharedContextForm } from "./components/SharedContextForm.js";
 import { CostEstimator } from "./components/CostEstimator.js";
 import { HealthDashboard } from "./components/HealthDashboard.js";
 import { ArchitectPanel } from "./components/ArchitectPanel.js";
-import { ThemeToggle } from "./components/ThemeToggle.js";
-import { IntentScopeBar } from "./components/IntentScopeBar.js";
-import type { Mode } from "@ficecal/ui-foundation";
+import { NavBar } from "./components/NavBar.js";
+import { ScenarioBar } from "./components/ScenarioBar.js";
+import type { AiCostResult } from "@ficecal/ai-token-economics";
+import type { DemoScenario } from "@ficecal/demo-scenarios";
 
 const DEFAULT_CONTEXT: SharedContext = {
   workspaceId: "workspace-finops-001",
@@ -17,11 +24,11 @@ const DEFAULT_CONTEXT: SharedContext = {
 };
 
 export function App() {
-  const { theme, intentScope, i18n, preferences } = useUiFoundation();
+  const { theme, i18n, preferences } = useUiFoundation();
 
-  // Sync mode from IntentScopeState → local React state for panel routing.
-  const [mode, setMode] = useState<Mode>(intentScope.get().mode);
   const [context, setContext] = useState<SharedContext>(DEFAULT_CONTEXT);
+  const [economicsResult, setEconomicsResult] = useState<AiCostResult | null>(null);
+  const [activeScenario, setActiveScenario] = useState<DemoScenario | null>(null);
 
   // Keep currency preference in sync with context currency.
   useEffect(() => {
@@ -36,43 +43,72 @@ export function App() {
     theme.apply();
   }, [theme]);
 
+  function handleScenarioLoad(scenario: DemoScenario) {
+    setActiveScenario(scenario);
+    // If scenario has a currency override, apply it to context
+    const overrideCurrency = scenario.inputs?.aiCost?.currency;
+    if (overrideCurrency && typeof overrideCurrency === "string") {
+      setContext((c) => ({ ...c, currency: overrideCurrency }));
+    }
+  }
+
   return (
     <div className="shell">
-      <header className="topbar">
-        <div className="topbar-brand">
+      <NavBar theme={theme} i18n={i18n} />
+
+      {/* ── Hero header ─────────────────────────────────────────────────────── */}
+      <header className="hero">
+        <div className="hero-brand">
           <p className="eyebrow">{i18n.t("ui.title")} v2</p>
           <h1>{i18n.t("ui.tagline")}</h1>
-          <p className="subtitle">
+          <p className="hero-sub">
             Deterministic cost intelligence — decimal-precise, audit-traceable.
           </p>
         </div>
-        <div className="topbar-actions">
-          <div className="mode-status" aria-live="polite">
-            <span className="mode-status-label">Active mode</span>
-            <strong className={`mode-badge mode-badge--${mode}`}>{mode}</strong>
-          </div>
-          <ThemeToggle theme={theme} i18n={i18n} />
+        <div className="hero-meta">
+          <span className="phase-tag">Phase 4 complete</span>
+          <span className="phase-tag phase-tag--muted">decimal.js 28dp</span>
+          <span className="phase-tag phase-tag--muted">formula-traced</span>
         </div>
       </header>
 
-      <IntentScopeBar
-        intentScope={intentScope}
-        i18n={i18n}
-        onModeChange={setMode}
-      />
-
+      {/* ── Workspace context ────────────────────────────────────────────────── */}
       <SharedContextForm context={context} onChange={setContext} />
 
+      {/* ── Scenario presets ─────────────────────────────────────────────────── */}
+      <ScenarioBar
+        onLoad={handleScenarioLoad}
+        activeId={activeScenario?.id}
+      />
+
       <main className="content-area" role="main">
-        {mode === "quick" && <CostEstimator context={context} />}
-        {mode === "operator" && <HealthDashboard context={context} />}
-        {mode === "architect" && <ArchitectPanel context={context} />}
+        {/* ── Cost estimator ──────────────────────────────────────────────── */}
+        <section id="calculator" className="anchor-section">
+          <CostEstimator
+            context={context}
+            onResult={setEconomicsResult}
+            scenarioOverride={activeScenario}
+          />
+        </section>
+
+        {/* ── Health dashboard ────────────────────────────────────────────── */}
+        <section id="health" className="anchor-section">
+          <HealthDashboard
+            context={context}
+            economicsResult={economicsResult}
+          />
+        </section>
+
+        {/* ── Architect panel ─────────────────────────────────────────────── */}
+        <section id="architect" className="anchor-section">
+          <ArchitectPanel context={context} />
+        </section>
       </main>
 
       <footer className="footer">
         <p>
-          {i18n.t("ui.title")} v2 · Phase 3 complete · All arithmetic via{" "}
-          <code>decimal.js</code> (28dp)
+          {i18n.t("ui.title")} v2 · Phase 4 complete · All arithmetic via{" "}
+          <code>decimal.js</code> (28dp) · formula-traced
         </p>
       </footer>
     </div>

--- a/apps/web/src/components/ArchitectPanel.tsx
+++ b/apps/web/src/components/ArchitectPanel.tsx
@@ -5,123 +5,70 @@ interface Props {
 }
 
 const PACKAGE_GRAPH = [
-  {
-    id: "core-economics",
-    status: "active",
-    phase: 1,
-    provides: ["cost-compute", "forex", "period-normalize"],
-    dependsOn: [],
-  },
-  {
-    id: "schemas",
-    status: "active",
-    phase: 0,
-    provides: ["model-pricing-schema"],
-    dependsOn: [],
-  },
-  {
-    id: "integrations",
-    status: "active",
-    phase: 0,
-    provides: ["model-pricing-data"],
-    dependsOn: ["schemas"],
-  },
-  {
-    id: "schemas.normalized-cost-record",
-    status: "active",
-    phase: 1,
-    provides: ["billing-record-contract"],
-    dependsOn: [],
-  },
-  {
-    id: "chart-presentation",
-    status: "active",
-    phase: 2,
-    provides: ["chart-payload"],
-    dependsOn: ["core-economics"],
-  },
-  {
-    id: "health-score",
-    status: "active",
-    phase: 2,
-    provides: ["health-signals"],
-    dependsOn: [],
-  },
-  {
-    id: "recommendation-module",
-    status: "active",
-    phase: 2,
-    provides: ["recommendations"],
-    dependsOn: ["health-score"],
-  },
-  {
-    id: "ai-token-economics",
-    status: "active",
-    phase: 2,
-    provides: ["ai-cost-compute"],
-    dependsOn: ["core-economics"],
-  },
-  {
-    id: "feature-registry",
-    status: "active",
-    phase: 3,
-    provides: ["plugin-registration"],
-    dependsOn: [],
-  },
-  {
-    id: "mcp-tooling",
-    status: "active",
-    phase: 3,
-    provides: ["mcp-tool-registry", "economics-tools"],
-    dependsOn: ["feature-registry", "core-economics", "ai-token-economics", "health-score", "recommendation-module"],
-  },
+  // Phase 0
+  { id: "schemas", phase: 0, provides: ["model-pricing-schema"], dependsOn: [] },
+  { id: "integrations", phase: 0, provides: ["model-pricing-data"], dependsOn: ["schemas"] },
+  { id: "schemas.normalized-cost-record", phase: 0, provides: ["billing-record-contract"], dependsOn: [] },
+  // Phase 1
+  { id: "core-economics", phase: 1, provides: ["cost-compute", "forex", "period-normalize"], dependsOn: [] },
+  // Phase 2
+  { id: "ai-token-economics", phase: 2, provides: ["ai-cost-compute"], dependsOn: ["core-economics"] },
+  { id: "sla-slo-sli-economics", phase: 2, provides: ["error-budget", "downtime-cost", "reliability-roi"], dependsOn: ["core-economics"] },
+  { id: "multi-tech-normalization", phase: 2, provides: ["tech-cost-normalize", "efficiency-index"], dependsOn: ["core-economics"] },
+  { id: "chart-presentation", phase: 2, provides: ["chart-payload"], dependsOn: ["core-economics"] },
+  { id: "health-score", phase: 2, provides: ["health-signals", "weighted-score"], dependsOn: [] },
+  { id: "recommendation-module", phase: 2, provides: ["recommendations"], dependsOn: ["health-score"] },
+  { id: "budgeting-forecasting", phase: 2, provides: ["budget-variance", "trend-extrapolation", "spend-projection"], dependsOn: ["core-economics"] },
+  { id: "reference-evidence", phase: 2, provides: ["evidence-catalog", "queryable-citations"], dependsOn: [] },
+  { id: "demo-scenarios", phase: 2, provides: ["canonical-fixtures"], dependsOn: ["ai-token-economics", "sla-slo-sli-economics", "budgeting-forecasting"] },
+  { id: "qa-module", phase: 2, provides: ["contract-harness", "engine-contracts"], dependsOn: ["health-score"] },
+  { id: "economics-module", phase: 2, provides: ["plugin-registry", "unified-economics-api"], dependsOn: ["ai-token-economics", "sla-slo-sli-economics", "multi-tech-normalization", "core-economics"] },
+  // Phase 3
+  { id: "ui-foundation", phase: 3, provides: ["intent-scope", "theme", "preferences", "i18n", "keyboard", "telemetry"], dependsOn: [] },
+  { id: "feature-registry", phase: 3, provides: ["plugin-registration", "topo-sort"], dependsOn: [] },
+  { id: "mcp-tooling", phase: 3, provides: ["mcp-tool-registry", "economics-tools"], dependsOn: ["feature-registry", "core-economics", "ai-token-economics", "health-score", "recommendation-module"] },
+  // Phase 4
+  { id: "contracts", phase: 4, provides: ["cross-package-boundary-types"], dependsOn: [] },
+  { id: "service-mcp (scaffold)", phase: 4, provides: ["mcp-http-transport (planned)"], dependsOn: ["mcp-tooling"] },
 ];
 
 const PHASE_TAGS: Record<number, string> = {
   0: "Phase 0 — baseline",
   1: "Phase 1 — economics kernel",
   2: "Phase 2 — module hardening",
-  3: "Phase 3 — registry & tooling",
+  3: "Phase 3 — UI foundation & tooling",
+  4: "Phase 4 — monorepo structure",
 };
 
 const ADR_ENTRIES = [
   { id: "ADR-0001", title: "D3-first chart rendering policy", status: "accepted" },
-  { id: "ADR-0002", title: "Decimal.js for all monetary arithmetic", status: "accepted" },
-  { id: "ADR-0003", title: "ForexRateProvider as injected named dependency", status: "accepted" },
-  { id: "ADR-0004", title: "Formula registry for cost computation traceability", status: "accepted" },
+  { id: "ADR-0002", title: "Fastify + MCP SDK transport stack", status: "accepted" },
+  { id: "ADR-0003", title: "Monorepo structure (apps/services/packages)", status: "accepted" },
+  { id: "ADR-0004", title: "EconomicsPlugin extension interface for all economics engines", status: "accepted" },
+  { id: "ADR-0005", title: "Decimal.js for all monetary arithmetic (28dp)", status: "accepted" },
+  { id: "ADR-0006", title: "ForexRateProvider as injected named dependency", status: "accepted" },
+  { id: "ADR-0007", title: "Formula registry for cost computation traceability", status: "accepted" },
 ];
 
 export function ArchitectPanel({ context }: Props) {
   return (
     <div className="panel-stack">
-      {/* ── Context trace ────────────────────────────────────────── */}
+      {/* ── Context trace ────────────────────────────────────────────────── */}
       <section className="panel" aria-label="Context trace">
         <h2>Context Trace</h2>
         <ul className="status-list">
-          <li>
-            <span className="label">Workspace</span>
-            <code>{context.workspaceId}</code>
-          </li>
-          <li>
-            <span className="label">Period</span>
-            <span>{context.startDate} → {context.endDate}</span>
-          </li>
-          <li>
-            <span className="label">Currency</span>
-            <code>{context.currency}</code>
-          </li>
-          <li>
-            <span className="label">Contract version</span>
-            <code>mcp=2.0 / feature-catalog=1.3.0</code>
-          </li>
+          <li><span className="label">Workspace</span><code>{context.workspaceId}</code></li>
+          <li><span className="label">Period</span><span>{context.startDate} → {context.endDate}</span></li>
+          <li><span className="label">Currency</span><code>{context.currency}</code></li>
+          <li><span className="label">feature-catalog</span><code>v1.6.0</code></li>
           <li>
             <span className="label">Phase exit tags</span>
-            <span>v2.0.0-phase-0-exit · v2.0.0-phase-1-exit · v2.0.0-phase-2-exit</span>
+            <span>phase-0 · phase-1 · phase-2 · phase-3 · phase-4 (in progress)</span>
           </li>
         </ul>
       </section>
 
-      {/* ── Package graph ─────────────────────────────────────────── */}
+      {/* ── Package graph ────────────────────────────────────────────────── */}
       <section className="panel" aria-label="Package dependency graph">
         <h2>Package Graph</h2>
         {Object.entries(PHASE_TAGS).map(([phase, label]) => {
@@ -151,7 +98,7 @@ export function ArchitectPanel({ context }: Props) {
         })}
       </section>
 
-      {/* ── ADRs ──────────────────────────────────────────────────── */}
+      {/* ── ADRs ─────────────────────────────────────────────────────────── */}
       <section className="panel" aria-label="Architecture decision records">
         <h2>Architecture Decisions</h2>
         <ul className="adr-list">

--- a/apps/web/src/components/CostChart.tsx
+++ b/apps/web/src/components/CostChart.tsx
@@ -1,0 +1,186 @@
+// ─── CostChart ────────────────────────────────────────────────────────────────
+//
+// D3-powered chart renderer for ChartPayload from @ficecal/chart-presentation.
+// ADR-0001: D3-first chart policy — D3 handles all scale + path computation;
+// React owns the component lifecycle and SVG host element.
+
+import { useRef, useEffect } from "react";
+import * as d3 from "d3";
+import type { ChartPayload } from "@ficecal/chart-presentation";
+
+interface Props {
+  payload: ChartPayload;
+  width?: number;
+  height?: number;
+}
+
+const MARGIN = { top: 20, right: 24, bottom: 48, left: 64 };
+
+export function CostChart({ payload, width = 560, height = 280 }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const innerW = width - MARGIN.left - MARGIN.right;
+  const innerH = height - MARGIN.top - MARGIN.bottom;
+
+  useEffect(() => {
+    if (!svgRef.current || !payload.renderable || payload.series.length === 0) return;
+
+    const series = payload.series[0]!;
+    const points = series.points;
+
+    // ── Scales ──────────────────────────────────────────────────────────────
+
+    const xScale = d3
+      .scaleBand()
+      .domain(points.map((p) => p.label))
+      .range([0, innerW])
+      .padding(0.25);
+
+    const yMax = d3.max(points, (p) => parseFloat(p.value)) ?? 0;
+    const yScale = d3
+      .scaleLinear()
+      .domain([0, yMax * 1.15])
+      .range([innerH, 0]);
+
+    // ── Clear previous render ────────────────────────────────────────────────
+
+    const svg = d3.select(svgRef.current);
+    svg.selectAll("*").remove();
+
+    const g = svg
+      .append("g")
+      .attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
+
+    // ── Gridlines ────────────────────────────────────────────────────────────
+
+    const accentColor = getComputedStyle(document.documentElement)
+      .getPropertyValue("--fc-accent")
+      .trim() || "#38bdf8";
+
+    g.append("g")
+      .attr("class", "grid")
+      .call(
+        d3.axisLeft(yScale)
+          .ticks(5)
+          .tickSize(-innerW)
+          .tickFormat(() => "")
+      )
+      .call((gEl) => gEl.select(".domain").remove())
+      .call((gEl) =>
+        gEl.selectAll("line")
+          .attr("stroke", "var(--fc-border, #334155)")
+          .attr("stroke-dasharray", "3,3")
+      );
+
+    // ── Bars ─────────────────────────────────────────────────────────────────
+
+    const barColor = series.colorHint ?? accentColor;
+
+    g.selectAll(".bar")
+      .data(points)
+      .enter()
+      .append("rect")
+      .attr("class", "bar")
+      .attr("x", (d) => xScale(d.label) ?? 0)
+      .attr("y", (d) => yScale(parseFloat(d.value)))
+      .attr("width", xScale.bandwidth())
+      .attr("height", (d) => innerH - yScale(parseFloat(d.value)))
+      .attr("fill", barColor)
+      .attr("rx", 4)
+      .attr("opacity", 0.9);
+
+    // ── Value labels on bars ──────────────────────────────────────────────────
+
+    g.selectAll(".bar-label")
+      .data(points)
+      .enter()
+      .append("text")
+      .attr("class", "bar-label")
+      .attr("x", (d) => (xScale(d.label) ?? 0) + xScale.bandwidth() / 2)
+      .attr("y", (d) => yScale(parseFloat(d.value)) - 6)
+      .attr("text-anchor", "middle")
+      .attr("font-size", "11")
+      .attr("fill", "var(--fc-text-muted, #94a3b8)")
+      .text((d) => d.displayValue ?? parseFloat(d.value).toFixed(2));
+
+    // ── Axes ─────────────────────────────────────────────────────────────────
+
+    g.append("g")
+      .attr("transform", `translate(0,${innerH})`)
+      .call(d3.axisBottom(xScale))
+      .call((gEl) => gEl.select(".domain").attr("stroke", "var(--fc-border, #334155)"))
+      .call((gEl) =>
+        gEl
+          .selectAll("text")
+          .attr("fill", "var(--fc-text-muted, #94a3b8)")
+          .attr("font-size", "11")
+      );
+
+    g.append("g")
+      .call(d3.axisLeft(yScale).ticks(5))
+      .call((gEl) => gEl.select(".domain").attr("stroke", "var(--fc-border, #334155)"))
+      .call((gEl) =>
+        gEl
+          .selectAll("text")
+          .attr("fill", "var(--fc-text-muted, #94a3b8)")
+          .attr("font-size", "11")
+      );
+
+    // ── Axis labels ───────────────────────────────────────────────────────────
+
+    g.append("text")
+      .attr("x", innerW / 2)
+      .attr("y", innerH + 40)
+      .attr("text-anchor", "middle")
+      .attr("font-size", "12")
+      .attr("fill", "var(--fc-text-muted, #94a3b8)")
+      .text(payload.xAxis.label);
+
+    g.append("text")
+      .attr("transform", "rotate(-90)")
+      .attr("x", -innerH / 2)
+      .attr("y", -50)
+      .attr("text-anchor", "middle")
+      .attr("font-size", "12")
+      .attr("fill", "var(--fc-text-muted, #94a3b8)")
+      .text(payload.yAxis.label);
+
+  }, [payload, innerW, innerH]);
+
+  if (!payload.renderable) {
+    return (
+      <div className="chart-placeholder" role="status">
+        <p className="chart-placeholder-reason">
+          ⚠ {payload.notRenderableReason ?? "Chart unavailable"}
+        </p>
+        <p className="hint">{payload.accessibility.summary}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chart-container">
+      <div className="chart-header">
+        <h3 className="chart-title">{payload.title}</h3>
+        {payload.subtitle && (
+          <p className="chart-subtitle">{payload.subtitle}</p>
+        )}
+      </div>
+      <svg
+        ref={svgRef}
+        width={width}
+        height={height}
+        role="img"
+        aria-label={payload.accessibility.ariaLabel}
+        style={{ maxWidth: "100%", height: "auto" }}
+      />
+      <p className="chart-provenance">
+        Formulas: {payload.provenance.formulaIds.join(", ") || "—"} ·{" "}
+        {new Date(payload.provenance.generatedAt).toLocaleTimeString()}
+        {payload.provenance.isStale && (
+          <span className="chart-stale"> ⚠ stale</span>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/CostEstimator.tsx
+++ b/apps/web/src/components/CostEstimator.tsx
@@ -1,10 +1,20 @@
-import { useState } from "react";
+// ─── CostEstimator ────────────────────────────────────────────────────────────
+//
+// Real-time AI cost estimator — computes on every input change (no button click).
+// Lifts result up via onResult so other panels (Health, Chart) can consume it.
+
+import { useState, useEffect, useCallback } from "react";
 import { computeAiCost } from "@ficecal/ai-token-economics";
+import { buildModelComparisonBarChart } from "@ficecal/chart-presentation";
 import type { AiCostInput, AiCostResult } from "@ficecal/ai-token-economics";
 import type { SharedContext, PricingUnit } from "../types.js";
+import { CostChart } from "./CostChart.js";
+import type { DemoScenario } from "@ficecal/demo-scenarios";
 
 interface Props {
   context: SharedContext;
+  onResult?: (result: AiCostResult | null) => void;
+  scenarioOverride?: DemoScenario | null;
 }
 
 const PRICING_UNITS: { value: PricingUnit; label: string }[] = [
@@ -16,7 +26,26 @@ const PRICING_UNITS: { value: PricingUnit; label: string }[] = [
   { value: "per_second", label: "Per second" },
 ];
 
-function buildInput(unit: PricingUnit, fields: Record<string, string>, currency: string): AiCostInput | null {
+const DEFAULT_FIELDS: Record<string, string> = {
+  inputTokens: "1000000",
+  outputTokens: "500000",
+  inputPrice: "0.50",
+  outputPrice: "1.50",
+  imageCount: "100",
+  pricePerImage: "0.040",
+  resolutionMultiplier: "",
+  requestCount: "1000",
+  pricePerRequest: "0.001",
+  durationSeconds: "3600",
+  pricePerSecond: "0.0001",
+  modelLabel: "Model A",
+};
+
+function buildInput(
+  unit: PricingUnit,
+  fields: Record<string, string>,
+  currency: string
+): AiCostInput | null {
   try {
     if (unit === "per_token" || unit === "per_1k_tokens" || unit === "per_1m_tokens") {
       return {
@@ -48,7 +77,6 @@ function buildInput(unit: PricingUnit, fields: Record<string, string>, currency:
         period: "monthly",
       };
     }
-    // per_second
     return {
       pricingUnit: "per_second",
       durationSeconds: Number(fields["durationSeconds"] ?? "0"),
@@ -61,58 +89,88 @@ function buildInput(unit: PricingUnit, fields: Record<string, string>, currency:
   }
 }
 
-export function CostEstimator({ context }: Props) {
+export function CostEstimator({ context, onResult, scenarioOverride }: Props) {
   const [unit, setUnit] = useState<PricingUnit>("per_1m_tokens");
-  const [fields, setFields] = useState<Record<string, string>>({
-    inputTokens: "1000000",
-    outputTokens: "500000",
-    inputPrice: "0.50",
-    outputPrice: "1.50",
-    imageCount: "100",
-    pricePerImage: "0.040",
-    resolutionMultiplier: "",
-    requestCount: "1000",
-    pricePerRequest: "0.001",
-    durationSeconds: "3600",
-    pricePerSecond: "0.0001",
-  });
+  const [fields, setFields] = useState<Record<string, string>>(DEFAULT_FIELDS);
   const [result, setResult] = useState<AiCostResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Apply scenario preset when provided
+  useEffect(() => {
+    if (!scenarioOverride?.inputs?.aiCost) return;
+    const ai = scenarioOverride.inputs.aiCost;
+    if (ai.pricingUnit) setUnit(ai.pricingUnit as PricingUnit);
+    setFields((f) => ({
+      ...f,
+      inputTokens: String(ai.inputTokens ?? f["inputTokens"]),
+      outputTokens: String(ai.outputTokens ?? f["outputTokens"]),
+      inputPrice: String(ai.inputPricePerUnit ?? f["inputPrice"]),
+      outputPrice: String(ai.outputPricePerUnit ?? f["outputPrice"]),
+    }));
+  }, [scenarioOverride]);
+
+  // Real-time compute on every input change
+  const compute = useCallback(() => {
+    const input = buildInput(unit, fields, context.currency);
+    if (!input) {
+      setResult(null);
+      setError("Invalid input — check required fields.");
+      onResult?.(null);
+      return;
+    }
+    try {
+      const r = computeAiCost(input);
+      setResult(r);
+      setError(null);
+      onResult?.(r);
+    } catch (e) {
+      setResult(null);
+      setError(e instanceof Error ? e.message : "Computation error");
+      onResult?.(null);
+    }
+  }, [unit, fields, context.currency, onResult]);
+
+  useEffect(() => {
+    compute();
+  }, [compute]);
 
   function setField(key: string, value: string) {
     setFields((f) => ({ ...f, [key]: value }));
   }
 
-  function handleCompute() {
-    setError(null);
-    const input = buildInput(unit, fields, context.currency);
-    if (!input) {
-      setError("Invalid input — check all required fields.");
-      return;
-    }
-    try {
-      setResult(computeAiCost(input));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Computation error");
-    }
-  }
+  // Build chart payload from result
+  const chartPayload = result
+    ? buildModelComparisonBarChart({
+        title: "AI cost breakdown",
+        subtitle: `${context.currency} · ${result.period}`,
+        period: result.period,
+        models: result.breakdown.map((line, i) => ({
+          modelId: `line-${i}`,
+          modelName: line.label,
+          cost: line.subtotal,
+          currency: context.currency,
+          displayValue: `${context.currency} ${parseFloat(line.subtotal).toFixed(4)}`,
+          pricingSourceType: "manual",
+        })),
+        formulaIds: result.formulasApplied,
+        dataSource: "apps/web:CostEstimator",
+      })
+    : null;
 
   return (
     <div className="panel-stack">
-      <section className="panel" aria-label="Cost estimator">
-        <h2>Cost Estimator</h2>
-        <p className="hint">
-          Compute AI inference cost using Decimal.js precision arithmetic.
-        </p>
+      <section className="panel" aria-label="AI cost estimator">
+        <div className="panel-header">
+          <h2>Cost Estimator</h2>
+          <p className="hint">Real-time · decimal.js 28dp · formula-traced</p>
+        </div>
 
         <div className="field-row">
           <label>
             Pricing unit
             <select value={unit} onChange={(e) => setUnit(e.target.value as PricingUnit)}>
               {PRICING_UNITS.map((u) => (
-                <option key={u.value} value={u.value}>
-                  {u.label}
-                </option>
+                <option key={u.value} value={u.value}>{u.label}</option>
               ))}
             </select>
           </label>
@@ -122,35 +180,23 @@ export function CostEstimator({ context }: Props) {
           <div className="field-grid">
             <label>
               Input tokens
-              <input
-                type="number"
-                value={fields["inputTokens"]}
-                onChange={(e) => setField("inputTokens", e.target.value)}
-              />
+              <input type="number" value={fields["inputTokens"]}
+                onChange={(e) => setField("inputTokens", e.target.value)} />
             </label>
             <label>
               Output tokens
-              <input
-                type="number"
-                value={fields["outputTokens"]}
-                onChange={(e) => setField("outputTokens", e.target.value)}
-              />
+              <input type="number" value={fields["outputTokens"]}
+                onChange={(e) => setField("outputTokens", e.target.value)} />
             </label>
             <label>
               Input price ({unit === "per_1m_tokens" ? "/1M" : unit === "per_1k_tokens" ? "/1K" : "/token"})
-              <input
-                type="text"
-                value={fields["inputPrice"]}
-                onChange={(e) => setField("inputPrice", e.target.value)}
-              />
+              <input type="text" value={fields["inputPrice"]}
+                onChange={(e) => setField("inputPrice", e.target.value)} />
             </label>
             <label>
-              Output price (optional, defaults to input price)
-              <input
-                type="text"
-                value={fields["outputPrice"]}
-                onChange={(e) => setField("outputPrice", e.target.value)}
-              />
+              Output price (optional)
+              <input type="text" value={fields["outputPrice"]}
+                onChange={(e) => setField("outputPrice", e.target.value)} />
             </label>
           </div>
         )}
@@ -159,28 +205,18 @@ export function CostEstimator({ context }: Props) {
           <div className="field-grid">
             <label>
               Image count
-              <input
-                type="number"
-                value={fields["imageCount"]}
-                onChange={(e) => setField("imageCount", e.target.value)}
-              />
+              <input type="number" value={fields["imageCount"]}
+                onChange={(e) => setField("imageCount", e.target.value)} />
             </label>
             <label>
               Price per image
-              <input
-                type="text"
-                value={fields["pricePerImage"]}
-                onChange={(e) => setField("pricePerImage", e.target.value)}
-              />
+              <input type="text" value={fields["pricePerImage"]}
+                onChange={(e) => setField("pricePerImage", e.target.value)} />
             </label>
             <label>
               Resolution multiplier (optional)
-              <input
-                type="text"
-                placeholder="e.g. 1.5"
-                value={fields["resolutionMultiplier"]}
-                onChange={(e) => setField("resolutionMultiplier", e.target.value)}
-              />
+              <input type="text" placeholder="e.g. 1.5" value={fields["resolutionMultiplier"]}
+                onChange={(e) => setField("resolutionMultiplier", e.target.value)} />
             </label>
           </div>
         )}
@@ -189,19 +225,13 @@ export function CostEstimator({ context }: Props) {
           <div className="field-grid">
             <label>
               Request count
-              <input
-                type="number"
-                value={fields["requestCount"]}
-                onChange={(e) => setField("requestCount", e.target.value)}
-              />
+              <input type="number" value={fields["requestCount"]}
+                onChange={(e) => setField("requestCount", e.target.value)} />
             </label>
             <label>
               Price per request
-              <input
-                type="text"
-                value={fields["pricePerRequest"]}
-                onChange={(e) => setField("pricePerRequest", e.target.value)}
-              />
+              <input type="text" value={fields["pricePerRequest"]}
+                onChange={(e) => setField("pricePerRequest", e.target.value)} />
             </label>
           </div>
         )}
@@ -210,88 +240,60 @@ export function CostEstimator({ context }: Props) {
           <div className="field-grid">
             <label>
               Duration (seconds)
-              <input
-                type="number"
-                value={fields["durationSeconds"]}
-                onChange={(e) => setField("durationSeconds", e.target.value)}
-              />
+              <input type="number" value={fields["durationSeconds"]}
+                onChange={(e) => setField("durationSeconds", e.target.value)} />
             </label>
             <label>
               Price per second
-              <input
-                type="text"
-                value={fields["pricePerSecond"]}
-                onChange={(e) => setField("pricePerSecond", e.target.value)}
-              />
+              <input type="text" value={fields["pricePerSecond"]}
+                onChange={(e) => setField("pricePerSecond", e.target.value)} />
             </label>
           </div>
         )}
 
-        <div className="action-row">
-          <button type="button" className="action-button" onClick={handleCompute}>
-            Compute cost
-          </button>
-        </div>
-
         {error && (
-          <div className="error-banner" role="alert">
-            <p>{error}</p>
-          </div>
+          <div className="error-banner" role="alert"><p>{error}</p></div>
         )}
       </section>
 
+      {/* ── Output cards ───────────────────────────────────────────────────── */}
       {result && (
-        <section className="panel result-panel" aria-label="Cost result">
-          <h2>Result</h2>
-          <div className="metric-row">
-            <span>Total cost</span>
-            <strong className="metric-value">
-              {context.currency} {result.totalCost}
+        <div className="output-cards" aria-label="Cost results">
+          <div className="output-card output-card--primary">
+            <span className="output-card-label">Total cost</span>
+            <strong className="output-card-value">
+              {context.currency} {parseFloat(result.totalCost).toFixed(4)}
             </strong>
+            <span className="output-card-sub">{result.period}</span>
           </div>
-          <div className="metric-row">
-            <span>Pricing unit</span>
-            <code>{result.pricingUnit}</code>
-          </div>
-          <div className="metric-row">
-            <span>Period</span>
-            <span>{result.period}</span>
-          </div>
-          {result.breakdown.length > 0 && (
-            <>
-              <h3>Breakdown</h3>
-              <table className="breakdown-table">
-                <thead>
-                  <tr>
-                    <th>Item</th>
-                    <th>Quantity</th>
-                    <th>Unit cost</th>
-                    <th>Subtotal</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {result.breakdown.map((line, i) => (
-                    <tr key={i}>
-                      <td>{line.label}</td>
-                      <td>{line.quantity.toLocaleString()}</td>
-                      <td><code>{line.unitCost}</code></td>
-                      <td><strong>{line.subtotal}</strong></td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </>
-          )}
-          {result.warnings.length > 0 && (
-            <div className="warnings">
-              {result.warnings.map((w, i) => (
-                <p key={i} className="warning-line">⚠ {w}</p>
-              ))}
+
+          {result.breakdown.map((line, i) => (
+            <div key={i} className="output-card">
+              <span className="output-card-label">{line.label}</span>
+              <strong className="output-card-value">
+                {context.currency} {parseFloat(line.subtotal).toFixed(4)}
+              </strong>
+              <span className="output-card-sub">
+                {line.quantity.toLocaleString()} × {line.unitCost}
+              </span>
             </div>
-          )}
-          <p className="formula-trace">
-            Formulas applied: {result.formulasApplied.join(", ")}
-          </p>
+          ))}
+        </div>
+      )}
+
+      {result && (
+        <p className="formula-trace">
+          Formulas: {result.formulasApplied.join(", ")}
+          {result.warnings.map((w, i) => (
+            <span key={i} className="warning-line"> · ⚠ {w}</span>
+          ))}
+        </p>
+      )}
+
+      {/* ── D3 chart ───────────────────────────────────────────────────────── */}
+      {chartPayload && chartPayload.series[0]?.points.length > 0 && (
+        <section className="panel chart-panel" aria-label="Cost chart">
+          <CostChart payload={chartPayload} />
         </section>
       )}
     </div>

--- a/apps/web/src/components/HealthDashboard.tsx
+++ b/apps/web/src/components/HealthDashboard.tsx
@@ -1,91 +1,132 @@
-import { useState } from "react";
+// ─── HealthDashboard ──────────────────────────────────────────────────────────
+//
+// Computes health score from a mix of economics-derived signals and baseline
+// signals. When an AiCostResult is available from CostEstimator, the
+// "cost-per-unit" and "model-trust" signals are derived from it dynamically.
+
+import { useMemo } from "react";
 import { computeHealthScore } from "@ficecal/health-score";
 import { computeRecommendations } from "@ficecal/recommendation-module";
-import type { HealthSignal, WeightedSignal } from "@ficecal/health-score";
+import type { WeightedSignal } from "@ficecal/health-score";
 import type { Recommendation } from "@ficecal/recommendation-module";
+import type { AiCostResult } from "@ficecal/ai-token-economics";
 import type { SharedContext } from "../types.js";
 
 interface Props {
   context: SharedContext;
+  economicsResult?: AiCostResult | null;
 }
 
-// Default demo signals so the dashboard is immediately useful
-const DEFAULT_SIGNALS: WeightedSignal[] = [
-  {
-    signal: {
-      id: "pricing-freshness-demo",
-      category: "pricing-freshness",
-      label: "Pricing freshness",
-      score: 75,
-      severity: "warning",
-      rationale: "Pricing data is 12 days old — past the 7-day warning threshold.",
-    },
-    weight: 2,
-  },
-  {
-    signal: {
-      id: "budget-adherence-demo",
-      category: "budget-adherence",
-      label: "Budget adherence",
-      score: 55,
-      severity: "warning",
-      rationale: "Spend at 88% of the monthly budget ceiling.",
-    },
-    weight: 3,
-  },
-  {
-    signal: {
-      id: "model-trust-demo",
-      category: "model-trust",
-      label: "Model trust",
-      score: 90,
-      severity: "ok",
-      rationale: "All active models use verified pricing sources.",
-    },
-    weight: 1,
-  },
-  {
-    signal: {
-      id: "data-completeness-demo",
-      category: "data-completeness",
-      label: "Data completeness",
-      score: 100,
-      severity: "ok",
-      rationale: "All billing records are complete.",
-    },
-    weight: 1,
-  },
-];
-
 const SEVERITY_COLOR: Record<string, string> = {
-  ok: "#16a34a",
-  warning: "#d97706",
-  critical: "#dc2626",
+  ok: "var(--fc-ok, #16a34a)",
+  warning: "var(--fc-warn, #d97706)",
+  critical: "var(--fc-crit, #dc2626)",
 };
 
 const PRIORITY_COLOR: Record<string, string> = {
-  critical: "#dc2626",
+  critical: "var(--fc-crit, #dc2626)",
   high: "#ea580c",
-  medium: "#d97706",
-  low: "#6b7280",
+  medium: "var(--fc-warn, #d97706)",
+  low: "var(--fc-text-muted, #6b7280)",
 };
 
-export function HealthDashboard({ context: _context }: Props) {
-  const [signals] = useState<WeightedSignal[]>(DEFAULT_SIGNALS);
+function deriveSignals(
+  context: SharedContext,
+  economicsResult: AiCostResult | null | undefined
+): WeightedSignal[] {
+  const signals: WeightedSignal[] = [];
+
+  // ── Derived from economics result ─────────────────────────────────────────
+
+  if (economicsResult) {
+    const totalCost = parseFloat(economicsResult.totalCost);
+    const hasWarnings = economicsResult.warnings.length > 0;
+
+    signals.push({
+      signal: {
+        id: "ai-cost-model-trust",
+        category: "model-trust",
+        label: "AI cost model",
+        score: hasWarnings ? 65 : 95,
+        severity: hasWarnings ? "warning" : "ok",
+        rationale: hasWarnings
+          ? `Computation warnings: ${economicsResult.warnings.join("; ")}`
+          : `${economicsResult.formulasApplied.length} formula(s) applied cleanly — decimal-precise outputs.`,
+      },
+      weight: 2,
+    });
+
+    signals.push({
+      signal: {
+        id: "ai-cost-unit-economics",
+        category: "pricing-freshness",
+        label: "Unit economics",
+        score: totalCost > 0 ? 90 : 50,
+        severity: totalCost > 0 ? "ok" : "warning",
+        rationale:
+          totalCost > 0
+            ? `Total cost ${context.currency} ${totalCost.toFixed(4)} — period: ${economicsResult.period}.`
+            : "No cost computed — verify input values.",
+      },
+      weight: 2,
+    });
+  }
+
+  // ── Baseline context signals ───────────────────────────────────────────────
+
+  const today = new Date();
+  const endDate = new Date(context.endDate);
+  const daysSinceEnd = Math.floor(
+    (today.getTime() - endDate.getTime()) / 86_400_000
+  );
+
+  signals.push({
+    signal: {
+      id: "data-period-freshness",
+      category: "pricing-freshness",
+      label: "Data period freshness",
+      score: daysSinceEnd <= 7 ? 100 : daysSinceEnd <= 30 ? 75 : 45,
+      severity: daysSinceEnd <= 7 ? "ok" : daysSinceEnd <= 30 ? "warning" : "critical",
+      rationale:
+        daysSinceEnd <= 0
+          ? "Analysis period is current or future."
+          : `Analysis period ended ${daysSinceEnd} day(s) ago.`,
+    },
+    weight: 1,
+  });
+
+  signals.push({
+    signal: {
+      id: "data-completeness-context",
+      category: "data-completeness",
+      label: "Context completeness",
+      score: context.workspaceId && context.currency ? 100 : 60,
+      severity: context.workspaceId && context.currency ? "ok" : "warning",
+      rationale:
+        context.workspaceId && context.currency
+          ? "Workspace ID and currency are set."
+          : "Missing workspace ID or currency — outputs may lack full context.",
+    },
+    weight: 1,
+  });
+
+  return signals;
+}
+
+export function HealthDashboard({ context, economicsResult }: Props) {
+  const signals = useMemo(
+    () => deriveSignals(context, economicsResult),
+    [context, economicsResult]
+  );
 
   const healthResult = computeHealthScore(signals);
   const recResult = computeRecommendations(signals.map((ws) => ws.signal));
 
-  const scoreColor =
-    healthResult.overallSeverity === "ok"
-      ? SEVERITY_COLOR["ok"]!
-      : healthResult.overallSeverity === "warning"
-        ? SEVERITY_COLOR["warning"]!
-        : SEVERITY_COLOR["critical"]!;
+  const scoreColor = SEVERITY_COLOR[healthResult.overallSeverity] ?? SEVERITY_COLOR["ok"]!;
 
   return (
     <div className="panel-stack">
-      {/* ── Score summary ────────────────────────────────────────── */}
+      {/* ── Score summary ────────────────────────────────────────────────── */}
       <section className="panel" aria-label="Health score summary">
         <h2>Health Score</h2>
         <div className="score-display">
@@ -97,24 +138,22 @@ export function HealthDashboard({ context: _context }: Props) {
             {healthResult.weightedScore.toFixed(0)}
           </span>
           <span className="score-label">/ 100</span>
-          <span
-            className="severity-badge"
-            style={{ backgroundColor: scoreColor }}
-          >
-            {healthResult.overallSeverity}
+          <span className="severity-badge" style={{ backgroundColor: scoreColor }}>
+            {healthResult.overallSeverity.toUpperCase()}
           </span>
         </div>
         <p className="hint">
-          Weighted aggregate across {signals.length} signals · computed{" "}
-          {new Date(healthResult.computedAt).toLocaleTimeString()}
+          Weighted aggregate across {signals.length} signals ·{" "}
+          {economicsResult ? "live economics wired" : "baseline signals only"} ·{" "}
+          computed {new Date(healthResult.computedAt).toLocaleTimeString()}
         </p>
       </section>
 
-      {/* ── Signal breakdown ─────────────────────────────────────── */}
+      {/* ── Signal breakdown ─────────────────────────────────────────────── */}
       <section className="panel" aria-label="Signal breakdown">
         <h2>Signals</h2>
         <ul className="signal-list">
-          {signals.map(({ signal }: { signal: HealthSignal }) => (
+          {signals.map(({ signal }) => (
             <li key={signal.id} className="signal-item">
               <div className="signal-header">
                 <span className="signal-label">{signal.label}</span>
@@ -132,7 +171,7 @@ export function HealthDashboard({ context: _context }: Props) {
         </ul>
       </section>
 
-      {/* ── Recommendations ───────────────────────────────────────── */}
+      {/* ── Recommendations ──────────────────────────────────────────────── */}
       <section className="panel" aria-label="Recommendations">
         <h2>Recommendations</h2>
         {recResult.recommendations.length === 0 ? (

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -1,0 +1,78 @@
+// ─── NavBar ───────────────────────────────────────────────────────────────────
+//
+// Sticky top navigation bar with section anchors, theme toggle, and active
+// section tracking via IntersectionObserver.
+
+import { useState, useEffect } from "react";
+import type { ThemeManager, LocalizationShell } from "@ficecal/ui-foundation";
+import { ThemeToggle } from "./ThemeToggle.js";
+
+interface NavSection {
+  id: string;
+  label: string;
+}
+
+const SECTIONS: NavSection[] = [
+  { id: "calculator", label: "Calculator" },
+  { id: "health", label: "Health" },
+  { id: "chart", label: "Chart" },
+  { id: "architect", label: "Architect" },
+];
+
+interface Props {
+  theme: ThemeManager;
+  i18n: LocalizationShell;
+}
+
+export function NavBar({ theme, i18n }: Props) {
+  const [activeSection, setActiveSection] = useState<string>("calculator");
+
+  useEffect(() => {
+    const observers: IntersectionObserver[] = [];
+
+    SECTIONS.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) setActiveSection(id);
+        },
+        { rootMargin: "-40% 0px -50% 0px" }
+      );
+      observer.observe(el);
+      observers.push(observer);
+    });
+
+    return () => observers.forEach((o) => o.disconnect());
+  }, []);
+
+  function scrollTo(id: string) {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  return (
+    <nav className="navbar" aria-label="FiceCal sections">
+      <div className="navbar-brand">
+        <span className="navbar-eyebrow">{i18n.t("ui.title")}</span>
+        <span className="navbar-tagline">{i18n.t("ui.tagline")}</span>
+      </div>
+
+      <ul className="navbar-links" role="list">
+        {SECTIONS.map(({ id, label }) => (
+          <li key={id}>
+            <button
+              className={`navbar-link${activeSection === id ? " is-active" : ""}`}
+              onClick={() => scrollTo(id)}
+              aria-current={activeSection === id ? "location" : undefined}
+            >
+              {label}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <ThemeToggle theme={theme} i18n={i18n} />
+    </nav>
+  );
+}

--- a/apps/web/src/components/ScenarioBar.tsx
+++ b/apps/web/src/components/ScenarioBar.tsx
@@ -1,0 +1,51 @@
+// ─── ScenarioBar ──────────────────────────────────────────────────────────────
+//
+// Preset scenario loader buttons from @ficecal/demo-scenarios.
+// Clicking a preset populates the CostEstimator and HealthDashboard inputs.
+
+import { getScenariosByDomain, type DemoScenario } from "@ficecal/demo-scenarios";
+
+export interface ScenarioPreset {
+  label: string;
+  scenario: DemoScenario;
+}
+
+interface Props {
+  onLoad: (scenario: DemoScenario) => void;
+  activeId?: string;
+}
+
+// Surface only the scenarios relevant to the browser runtime
+const AI_SCENARIOS = getScenariosByDomain("ai.token");
+const RELIABILITY_SCENARIOS = getScenariosByDomain("reliability.error-budget");
+const BUDGET_SCENARIOS = getScenariosByDomain("budgeting");
+
+const ALL_PRESETS: DemoScenario[] = [
+  ...AI_SCENARIOS,
+  ...RELIABILITY_SCENARIOS,
+  ...BUDGET_SCENARIOS,
+  ...getScenariosByDomain("tech.normalization"),
+];
+
+export function ScenarioBar({ onLoad, activeId }: Props) {
+  if (ALL_PRESETS.length === 0) return null;
+
+  return (
+    <div className="scenario-bar" aria-label="Load preset scenario">
+      <span className="scenario-bar-label">Presets</span>
+      <div className="scenario-bar-buttons">
+        {ALL_PRESETS.map((s) => (
+          <button
+            key={s.id}
+            className={`scenario-btn${activeId === s.id ? " is-active" : ""}`}
+            onClick={() => onLoad(s)}
+            title={s.description}
+            aria-pressed={activeId === s.id}
+          >
+            {s.title}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,123 +1,470 @@
 /* ── Reset & base ─────────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* ── Dark theme (default) CSS custom properties ───────────────────────────── */
 :root {
-  --color-bg: #0f172a;
-  --color-surface: #1e293b;
-  --color-surface-2: #273348;
-  --color-border: #334155;
-  --color-text: #e2e8f0;
-  --color-text-muted: #94a3b8;
-  --color-accent: #38bdf8;
-  --color-ok: #16a34a;
-  --color-warn: #d97706;
-  --color-crit: #dc2626;
-  --radius: 10px;
-  --gap: 1.25rem;
-  --font: "Plus Jakarta Sans", system-ui, sans-serif;
+  --fc-bg:           #0f172a;
+  --fc-surface:      #1e293b;
+  --fc-surface-2:    #273348;
+  --fc-border:       #334155;
+  --fc-text:         #e2e8f0;
+  --fc-text-muted:   #94a3b8;
+  --fc-accent:       #38bdf8;
+  --fc-ok:           #16a34a;
+  --fc-warn:         #d97706;
+  --fc-crit:         #dc2626;
+  --fc-radius:       10px;
+  --fc-gap:          1.25rem;
+  --fc-font:         "Plus Jakarta Sans", system-ui, sans-serif;
+  --fc-mono:         "Fira Code", "Cascadia Code", monospace;
+
+  /* Legacy aliases used by health-score & recommendation-module inline styles */
+  --color-bg:        var(--fc-bg);
+  --color-surface:   var(--fc-surface);
+  --color-surface-2: var(--fc-surface-2);
+  --color-border:    var(--fc-border);
+  --color-text:      var(--fc-text);
+  --color-text-muted:var(--fc-text-muted);
+  --color-accent:    var(--fc-accent);
+  --color-ok:        var(--fc-ok);
+  --color-warn:      var(--fc-warn);
+  --color-crit:      var(--fc-crit);
 }
 
-html { font-size: 16px; }
-body { font-family: var(--font); background: var(--color-bg); color: var(--color-text); min-height: 100vh; }
+/* ── Light theme ──────────────────────────────────────────────────────────── */
+[data-theme="light"] {
+  --fc-bg:           #f8fafc;
+  --fc-surface:      #ffffff;
+  --fc-surface-2:    #f1f5f9;
+  --fc-border:       #e2e8f0;
+  --fc-text:         #0f172a;
+  --fc-text-muted:   #64748b;
+  --fc-accent:       #0284c7;
+  --fc-ok:           #16a34a;
+  --fc-warn:         #d97706;
+  --fc-crit:         #dc2626;
+
+  --color-bg:        var(--fc-bg);
+  --color-surface:   var(--fc-surface);
+  --color-surface-2: var(--fc-surface-2);
+  --color-border:    var(--fc-border);
+  --color-text:      var(--fc-text);
+  --color-text-muted:var(--fc-text-muted);
+  --color-accent:    var(--fc-accent);
+  --color-ok:        var(--fc-ok);
+  --color-warn:      var(--fc-warn);
+  --color-crit:      var(--fc-crit);
+}
+
+/* ── Base ─────────────────────────────────────────────────────────────────── */
+html { font-size: 16px; scroll-behavior: smooth; }
+body {
+  font-family: var(--fc-font);
+  background: var(--fc-bg);
+  color: var(--fc-text);
+  min-height: 100vh;
+  transition: background 0.2s, color 0.2s;
+}
+code { font-family: var(--fc-mono); font-size: 0.85em; }
 
 /* ── Shell layout ────────────────────────────────────────────────────────── */
-.shell { max-width: 1100px; margin: 0 auto; padding: 1.5rem; display: flex; flex-direction: column; gap: var(--gap); }
+.shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-gap);
+}
 
-/* ── Topbar ──────────────────────────────────────────────────────────────── */
-.topbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; padding: 1.5rem; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius); }
-.topbar-brand .eyebrow { font-size: 0.75rem; font-weight: 600; color: var(--color-accent); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.25rem; }
-.topbar h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.25rem; }
-.topbar .subtitle { font-size: 0.875rem; color: var(--color-text-muted); }
-.mode-status { display: flex; flex-direction: column; align-items: flex-end; gap: 0.25rem; }
-.mode-status-label { font-size: 0.7rem; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
-.mode-badge { font-size: 0.8rem; font-weight: 700; padding: 0.2rem 0.6rem; border-radius: 999px; background: var(--color-accent); color: #0f172a; }
-.mode-badge--operator { background: #a78bfa; }
-.mode-badge--architect { background: #fb923c; }
+/* ── NavBar ───────────────────────────────────────────────────────────────── */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 1.25rem;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius);
+  margin: 0.75rem 0 0;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.navbar-brand {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+.navbar-eyebrow {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--fc-accent);
+}
+.navbar-tagline {
+  font-size: 0.68rem;
+  color: var(--fc-text-muted);
+}
+.navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  list-style: none;
+}
+.navbar-link {
+  display: block;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  font-family: var(--fc-font);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--fc-text-muted);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+.navbar-link:hover { background: var(--fc-surface-2); color: var(--fc-text); }
+.navbar-link.is-active { background: var(--fc-accent); color: #fff; font-weight: 700; }
+[data-theme="light"] .navbar-link.is-active { color: #0f172a; }
+
+/* ── Theme toggle ─────────────────────────────────────────────────────────── */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--fc-border);
+  background: transparent;
+  color: var(--fc-text-muted);
+  font-family: var(--fc-font);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.theme-toggle:hover { border-color: var(--fc-accent); color: var(--fc-accent); }
+.theme-toggle-label { font-size: 0.78rem; }
+
+/* ── Hero header ─────────────────────────────────────────────────────────── */
+.hero {
+  padding: 2rem 1.5rem;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.hero-brand .eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--fc-accent);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.3rem;
+}
+.hero-brand h1 { font-size: 1.75rem; font-weight: 800; line-height: 1.2; margin-bottom: 0.4rem; }
+.hero-sub { font-size: 0.9rem; color: var(--fc-text-muted); max-width: 480px; }
+.hero-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 0.4rem; }
+.phase-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: var(--fc-accent);
+  color: #fff;
+}
+[data-theme="light"] .phase-tag { color: #0f172a; }
+.phase-tag--muted { background: var(--fc-surface-2); color: var(--fc-text-muted); }
+
+/* ── Intent-scope bar ────────────────────────────────────────────────────── */
+.intent-scope-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius);
+}
+.intent-scope-fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+}
+.intent-scope-fields label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--fc-text-muted);
+}
+.intent-scope-fields select {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.5rem;
+  background: var(--fc-surface-2);
+  border: 1px solid var(--fc-border);
+  border-radius: 6px;
+  color: var(--fc-text);
+}
+.back-btn {
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--fc-border);
+  background: transparent;
+  color: var(--fc-text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.back-btn:hover { border-color: var(--fc-accent); color: var(--fc-accent); }
+.scope-hint {
+  font-size: 0.7rem;
+  color: var(--fc-warn);
+  font-style: italic;
+}
+
+/* ── Scenario bar ────────────────────────────────────────────────────────── */
+.scenario-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius);
+  flex-wrap: wrap;
+}
+.scenario-bar-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fc-text-muted);
+  white-space: nowrap;
+}
+.scenario-bar-buttons { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.scenario-btn {
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--fc-border);
+  background: transparent;
+  color: var(--fc-text-muted);
+  font-family: var(--fc-font);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.scenario-btn:hover { border-color: var(--fc-accent); color: var(--fc-accent); }
+.scenario-btn.is-active {
+  background: var(--fc-accent);
+  border-color: var(--fc-accent);
+  color: #fff;
+  font-weight: 700;
+}
+[data-theme="light"] .scenario-btn.is-active { color: #0f172a; }
 
 /* ── Panel ───────────────────────────────────────────────────────────────── */
-.panel { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius); padding: 1.5rem; }
-.panel h2 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; color: var(--color-text); }
-.panel h3 { font-size: 0.875rem; font-weight: 600; margin: 1rem 0 0.5rem; color: var(--color-text-muted); }
-.panel-stack { display: flex; flex-direction: column; gap: var(--gap); }
-.hint { font-size: 0.8rem; color: var(--color-text-muted); margin-bottom: 0.75rem; }
+.panel {
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius);
+  padding: 1.5rem;
+}
+.panel h2 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; }
+.panel h3 { font-size: 0.875rem; font-weight: 600; margin: 1rem 0 0.5rem; color: var(--fc-text-muted); }
+.panel-stack { display: flex; flex-direction: column; gap: var(--fc-gap); }
+.panel-header { margin-bottom: 1rem; }
+.panel-header h2 { margin-bottom: 0.25rem; }
+.hint { font-size: 0.8rem; color: var(--fc-text-muted); margin-bottom: 0.75rem; }
 
-/* ── Mode selector ────────────────────────────────────────────────────────── */
-.mode-switch { display: flex; gap: 0.5rem; }
-.mode-button { padding: 0.5rem 1.25rem; border-radius: 999px; border: 1px solid var(--color-border); background: transparent; color: var(--color-text-muted); font-family: var(--font); font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: all 0.15s; }
-.mode-button:hover { border-color: var(--color-accent); color: var(--color-accent); }
-.mode-button.is-active, .mode-button[aria-selected="true"] { background: var(--color-accent); border-color: var(--color-accent); color: #0f172a; font-weight: 700; }
+/* ── Anchor sections ─────────────────────────────────────────────────────── */
+.anchor-section { scroll-margin-top: 70px; }
+.content-area { display: flex; flex-direction: column; gap: var(--fc-gap); }
 
 /* ── Context form ────────────────────────────────────────────────────────── */
 .context-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
-label { display: flex; flex-direction: column; gap: 0.35rem; font-size: 0.8rem; font-weight: 500; color: var(--color-text-muted); }
-input, select { background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text); font-family: var(--font); font-size: 0.875rem; padding: 0.4rem 0.6rem; }
-input:focus, select:focus { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--fc-text-muted);
+}
+input, select {
+  background: var(--fc-surface-2);
+  border: 1px solid var(--fc-border);
+  border-radius: 6px;
+  color: var(--fc-text);
+  font-family: var(--fc-font);
+  font-size: 0.875rem;
+  padding: 0.4rem 0.6rem;
+  transition: border-color 0.15s;
+}
+input:focus, select:focus { outline: 2px solid var(--fc-accent); outline-offset: 1px; }
 
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
 .action-row { margin-top: 1rem; }
-.action-button { background: var(--color-accent); color: #0f172a; border: none; border-radius: 6px; font-family: var(--font); font-size: 0.875rem; font-weight: 700; padding: 0.55rem 1.25rem; cursor: pointer; transition: opacity 0.15s; }
+.action-button {
+  background: var(--fc-accent);
+  color: #0f172a;
+  border: none;
+  border-radius: 6px;
+  font-family: var(--fc-font);
+  font-size: 0.875rem;
+  font-weight: 700;
+  padding: 0.55rem 1.25rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
 .action-button:hover { opacity: 0.85; }
 
 /* ── Field grid (estimator form) ─────────────────────────────────────────── */
 .field-row { margin-bottom: 1rem; }
 .field-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
 
-/* ── Result panel ────────────────────────────────────────────────────────── */
-.result-panel { border-color: var(--color-accent); }
-.metric-row { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid var(--color-border); font-size: 0.875rem; }
-.metric-row:last-of-type { border-bottom: none; }
-.metric-value { font-size: 1.25rem; font-weight: 700; color: var(--color-accent); }
+/* ── Output cards ────────────────────────────────────────────────────────── */
+.output-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+.output-card {
+  background: var(--fc-surface-2);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.output-card--primary {
+  border-color: var(--fc-accent);
+  background: color-mix(in srgb, var(--fc-accent) 8%, var(--fc-surface-2));
+}
+.output-card-label { font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fc-text-muted); }
+.output-card-value { font-size: 1.4rem; font-weight: 800; color: var(--fc-accent); line-height: 1.2; }
+.output-card--primary .output-card-value { color: var(--fc-accent); }
+.output-card-sub { font-size: 0.72rem; color: var(--fc-text-muted); font-family: var(--fc-mono); }
 
-.breakdown-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin-top: 0.5rem; }
-.breakdown-table th, .breakdown-table td { padding: 0.4rem 0.6rem; text-align: left; border-bottom: 1px solid var(--color-border); }
-.breakdown-table th { color: var(--color-text-muted); font-weight: 600; }
+/* ── Chart ───────────────────────────────────────────────────────────────── */
+.chart-panel { overflow-x: auto; }
+.chart-container { display: flex; flex-direction: column; gap: 0.5rem; }
+.chart-header { }
+.chart-title { font-size: 0.9rem; font-weight: 600; }
+.chart-subtitle { font-size: 0.78rem; color: var(--fc-text-muted); margin-top: 0.2rem; }
+.chart-provenance { font-size: 0.68rem; color: var(--fc-text-muted); margin-top: 0.25rem; }
+.chart-stale { color: var(--fc-warn); }
+.chart-placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+  text-align: center;
+  border: 1px dashed var(--fc-border);
+  border-radius: var(--fc-radius);
+}
+.chart-placeholder-reason { font-size: 0.875rem; color: var(--fc-warn); }
 
-.formula-trace { font-size: 0.7rem; color: var(--color-text-muted); margin-top: 0.75rem; }
-.warnings { margin-top: 0.75rem; }
-.warning-line { font-size: 0.8rem; color: var(--color-warn); }
-.error-banner { background: rgba(220, 38, 38, 0.1); border: 1px solid var(--color-crit); border-radius: 6px; padding: 0.75rem 1rem; margin-top: 0.75rem; font-size: 0.875rem; color: var(--color-crit); }
+/* ── Formula trace ───────────────────────────────────────────────────────── */
+.formula-trace { font-size: 0.7rem; color: var(--fc-text-muted); margin-top: 0.75rem; font-family: var(--fc-mono); }
+.warning-line { font-size: 0.8rem; color: var(--fc-warn); }
+.error-banner {
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid var(--fc-crit);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--fc-crit);
+}
 
-/* ── Health dashboard ───────────────────────────────────────────────────── */
+/* ── Health dashboard ────────────────────────────────────────────────────── */
 .score-display { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
 .score-number { font-size: 3rem; font-weight: 800; line-height: 1; }
-.score-label { font-size: 1rem; color: var(--color-text-muted); }
+.score-label { font-size: 1rem; color: var(--fc-text-muted); }
 .severity-badge { padding: 0.2rem 0.7rem; border-radius: 999px; font-size: 0.75rem; font-weight: 700; color: #fff; text-transform: uppercase; }
 .severity-pill { padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.7rem; font-weight: 600; color: #fff; }
 .signal-list { list-style: none; display: flex; flex-direction: column; gap: 0.75rem; }
-.signal-item { background: var(--color-surface-2); border-radius: 6px; padding: 0.75rem; }
+.signal-item { background: var(--fc-surface-2); border-radius: 6px; padding: 0.75rem; }
 .signal-header { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.35rem; }
 .signal-label { font-weight: 600; font-size: 0.875rem; flex: 1; }
 .signal-score { font-weight: 700; font-size: 0.875rem; }
-.signal-rationale { font-size: 0.78rem; color: var(--color-text-muted); }
+.signal-rationale { font-size: 0.78rem; color: var(--fc-text-muted); }
 
 .rec-list { list-style: none; display: flex; flex-direction: column; gap: 0.75rem; }
-.rec-item { background: var(--color-surface-2); border-radius: 6px; padding: 0.75rem; }
+.rec-item { background: var(--fc-surface-2); border-radius: 6px; padding: 0.75rem; }
 .rec-header { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.35rem; flex-wrap: wrap; }
 .priority-badge { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; padding: 0.15rem 0.5rem; border-radius: 999px; border: 1.5px solid; }
-.audience-tag { font-size: 0.7rem; color: var(--color-text-muted); background: var(--color-surface); padding: 0.15rem 0.5rem; border-radius: 4px; }
+.audience-tag { font-size: 0.7rem; color: var(--fc-text-muted); background: var(--fc-surface); padding: 0.15rem 0.5rem; border-radius: 4px; }
 .rec-title { font-size: 0.875rem; font-weight: 600; flex: 1; }
-.rec-action { font-size: 0.8rem; color: var(--color-text-muted); }
+.rec-action { font-size: 0.8rem; color: var(--fc-text-muted); }
 
 /* ── Architect panel ─────────────────────────────────────────────────────── */
 .status-list { list-style: none; display: flex; flex-direction: column; gap: 0.6rem; }
-.status-list li { display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem; padding: 0.4rem 0; border-bottom: 1px solid var(--color-border); }
+.status-list li { display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem; padding: 0.4rem 0; border-bottom: 1px solid var(--fc-border); }
 .status-list li:last-child { border-bottom: none; }
-.label { color: var(--color-text-muted); }
+.label { color: var(--fc-text-muted); }
 .phase-group { margin-bottom: 1rem; }
-.phase-label { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; color: var(--color-accent); letter-spacing: 0.06em; margin-bottom: 0.5rem; }
+.phase-label { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; color: var(--fc-accent); letter-spacing: 0.06em; margin-bottom: 0.5rem; }
 .pkg-list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
-.pkg-item { background: var(--color-surface-2); border-radius: 6px; padding: 0.6rem 0.75rem; }
+.pkg-item { background: var(--fc-surface-2); border-radius: 6px; padding: 0.6rem 0.75rem; }
 .pkg-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.2rem; }
 .pkg-id { font-size: 0.825rem; font-weight: 600; }
-.pkg-meta { font-size: 0.75rem; color: var(--color-text-muted); display: flex; flex-direction: column; gap: 0.1rem; }
-.status-dot--active { width: 8px; height: 8px; border-radius: 50%; background: var(--color-ok); flex-shrink: 0; }
+.pkg-meta { font-size: 0.75rem; color: var(--fc-text-muted); display: flex; flex-direction: column; gap: 0.1rem; }
+.status-dot--active { width: 8px; height: 8px; border-radius: 50%; background: var(--fc-ok); flex-shrink: 0; }
 .adr-list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
-.adr-item { display: flex; align-items: center; gap: 0.75rem; font-size: 0.825rem; padding: 0.4rem 0; border-bottom: 1px solid var(--color-border); }
+.adr-item { display: flex; align-items: center; gap: 0.75rem; font-size: 0.825rem; padding: 0.4rem 0; border-bottom: 1px solid var(--fc-border); }
 .adr-item:last-child { border-bottom: none; }
-.adr-item code { font-size: 0.75rem; color: var(--color-accent); min-width: 80px; }
+.adr-item code { font-size: 0.75rem; color: var(--fc-accent); min-width: 80px; }
 .adr-item span:nth-child(2) { flex: 1; }
-.adr-status { font-size: 0.7rem; font-weight: 600; color: var(--color-ok); }
+.adr-status { font-size: 0.7rem; font-weight: 600; color: var(--fc-ok); }
+
+/* ── Mode selector (legacy — kept for IntentScopeBar compatibility) ────────── */
+.mode-switch { display: flex; gap: 0.5rem; }
+.mode-button {
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--fc-border);
+  background: transparent;
+  color: var(--fc-text-muted);
+  font-family: var(--fc-font);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.mode-button:hover { border-color: var(--fc-accent); color: var(--fc-accent); }
+.mode-button.is-active, .mode-button[aria-selected="true"] {
+  background: var(--fc-accent);
+  border-color: var(--fc-accent);
+  color: #0f172a;
+  font-weight: 700;
+}
 
 /* ── Footer ──────────────────────────────────────────────────────────────── */
-.footer { text-align: center; font-size: 0.75rem; color: var(--color-text-muted); padding: 1rem 0; }
-code { font-family: "Fira Code", "Cascadia Code", monospace; font-size: 0.85em; }
+.footer { text-align: center; font-size: 0.75rem; color: var(--fc-text-muted); padding: 1.5rem 0 0.5rem; border-top: 1px solid var(--fc-border); margin-top: 1rem; }
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .hero { flex-direction: column; align-items: flex-start; }
+  .hero-meta { align-items: flex-start; flex-direction: row; flex-wrap: wrap; }
+  .navbar-links { display: none; }
+  .output-cards { grid-template-columns: 1fr 1fr; }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,18 +13,33 @@ importers:
       '@ficecal/ai-token-economics':
         specifier: workspace:*
         version: link:../../packages/ai-token-economics
+      '@ficecal/budgeting-forecasting':
+        specifier: workspace:*
+        version: link:../../packages/budgeting-forecasting
+      '@ficecal/chart-presentation':
+        specifier: workspace:*
+        version: link:../../packages/chart-presentation
       '@ficecal/core-economics':
         specifier: workspace:*
         version: link:../../packages/core-economics
+      '@ficecal/demo-scenarios':
+        specifier: workspace:*
+        version: link:../../packages/demo-scenarios
       '@ficecal/health-score':
         specifier: workspace:*
         version: link:../../packages/health-score
+      '@ficecal/multi-tech-normalization':
+        specifier: workspace:*
+        version: link:../../packages/multi-tech-normalization
       '@ficecal/recommendation-module':
         specifier: workspace:*
         version: link:../../packages/recommendation-module
       '@ficecal/ui-foundation':
         specifier: workspace:*
         version: link:../../packages/ui-foundation
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -32,6 +47,9 @@ importers:
         specifier: ^18.3.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@types/d3':
+        specifier: ^7.4.0
+        version: 7.4.3
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.28
@@ -741,11 +759,107 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -854,11 +968,142 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -875,6 +1120,9 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  delaunator@5.0.1:
+    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
@@ -915,6 +1163,14 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -990,10 +1246,19 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  robust-predicates@3.0.2:
+    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1472,9 +1737,128 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/node@22.19.15':
     dependencies:
@@ -1611,9 +1995,163 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  commander@7.2.0: {}
+
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.0.1
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
 
   debug@4.4.3:
     dependencies:
@@ -1622,6 +2160,10 @@ snapshots:
   decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
+
+  delaunator@5.0.1:
+    dependencies:
+      robust-predicates: 3.0.2
 
   electron-to-chromium@1.5.321: {}
 
@@ -1669,6 +2211,12 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  internmap@2.0.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -1726,6 +2274,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  robust-predicates@3.0.2: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -1756,6 +2306,10 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.23.2:
     dependencies:


### PR DESCRIPTION
## Summary

- **App.tsx rewrite**: Single-page layout with all panels always visible (Calculator, Health, Architect); ScenarioBar preset loading; `economicsResult` lifted from `CostEstimator → HealthDashboard`; NavBar wired; hero header with phase tags
- **NavBar**: Sticky nav + IntersectionObserver active-section tracking; ThemeToggle inline; smooth-scroll anchors
- **ScenarioBar**: Preset buttons from `@ficecal/demo-scenarios` (ai.token · reliability · budgeting · tech.normalization); `is-active` highlight
- **CostEstimator** (rewrite): Real-time onChange compute (no button click); output-cards grid (primary total + per-line cards); `ChartPayload → CostChart` D3 render; `scenarioOverride` preset wiring; `onResult` lift
- **CostChart** (new): D3-first bar chart renderer per ADR-0001; `scaleBand + scaleLinear + axisBottom/Left`; reads `--fc-accent/--fc-border` CSS vars; graceful degradation when `renderable: false`
- **HealthDashboard** (rewrite): Derives `WeightedSignal[]` from `AiCostResult` + baseline context signals; `"live economics wired"` vs `"baseline signals only"` hint
- **ArchitectPanel** (update): 19 packages across Phases 0–4, 7 ADRs, feature-catalog v1.6.0, all phase exit tags
- **styles.css** (overhaul): `[data-theme="light"]` CSS vars; `--fc-*` token system; navbar · hero · scenario-bar · output-cards · chart · intent-scope-bar styles; responsive breakpoints
- **package.json**: `d3 ^7.9.0`, `@types/d3`, `budgeting-forecasting`, `chart-presentation`, `demo-scenarios`, `multi-tech-normalization` workspace deps

## Phase 4 exit criteria

- [x] TypeScript strict — `tsc --noEmit` clean
- [x] D3-first chart rendering (ADR-0001) — `CostChart` renders via D3 scales/axes, React owns SVG host
- [x] Real-time cost compute — no button click required
- [x] Economics result lifted to HealthDashboard — live signal derivation
- [x] ScenarioBar wired to CostEstimator preset override
- [x] Single-page layout with anchor-section scroll and NavBar active tracking
- [x] Light/dark theme CSS vars complete (`[data-theme="light"]`)
- [x] Monorepo packages: `packages/contracts/`, `services/mcp/`, CODEOWNERS, runbook (prior commits)

## Test plan

- [ ] Load `localhost:5173` — all panels visible without mode switching
- [ ] NavBar highlights active section on scroll
- [ ] Theme toggle cycles light → dark → system; page colours update
- [ ] Click a scenario preset — CostEstimator pre-fills, result updates, chart renders
- [ ] Edit any estimator field — result and chart update instantly (real-time)
- [ ] HealthDashboard shows "live economics wired" with score derived from result
- [ ] Light mode: legible contrast on all panels, chart labels, badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scenario preset loading with customizable inputs.
  * Integrated cost visualization using interactive charts.
  * Introduced persistent section navigation bar.

* **Improvements**
  * All three main panels (calculator, health, architect) now display simultaneously instead of switching between modes.
  * Health dashboard now incorporates economics data for real-time signal scoring.
  * Cost estimator now auto-computes results based on inputs.
  * Updated architecture information reflecting Phase 4 completion.

* **Style**
  * Comprehensive visual redesign with updated color variables, layouts, and responsive breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->